### PR TITLE
feat: Phase 5 — Search History & Favorites

### DIFF
--- a/docs/agent-session.md
+++ b/docs/agent-session.md
@@ -351,6 +351,47 @@
 - **Tests:** 179 passing (117 domain + 60 application + 2 boilerplate)
 
 ### Next Steps
-1. **Phase 5:** Search history + favorites endpoints
+1. ~~**Phase 5:** Search history + favorites endpoints~~ ✅
 2. **Phase 6:** Rate limiting + CAPTCHA
 3. **Phase 7:** Email verification + password reset
+
+---
+
+## Session #6 — 2026-02-12
+
+### State: Phase 5 — Search History & Favorites
+
+**Status:** COMPLETE
+
+### Tasks Performed
+
+#### 1. Search History Service
+- **File:** `src/CarCheck.Application/History/SearchHistoryService.cs`
+- **Features:** Paginated history with car details enrichment, today's search count, page/size clamping (1-100)
+
+#### 2. Favorite Service
+- **File:** `src/CarCheck.Application/Favorites/FavoriteService.cs`
+- **Features:** Add/remove/list favorites with car detail enrichment, duplicate prevention, existence checks
+
+#### 3. DTOs
+- **Files:** `History/DTOs/HistoryDTOs.cs`, `Favorites/DTOs/FavoriteDTOs.cs`
+- **Records:** SearchHistoryResponse, SearchHistoryPageResponse, FavoriteResponse, FavoritePageResponse, AddFavoriteRequest
+
+#### 4. API Endpoints
+- **`GET /api/history`** — Paginated search history (auth required)
+- **`GET /api/favorites`** — Paginated favorites list (auth required)
+- **`POST /api/favorites`** — Add car to favorites (auth required)
+- **`DELETE /api/favorites/{carId}`** — Remove from favorites (auth required)
+
+#### 5. Unit Tests (11 new)
+- **SearchHistoryServiceTests** (4 tests): Paged results, deleted car handling, empty results, page clamping
+- **FavoriteServiceTests** (7 tests): List, add (valid/not found/duplicate), remove (exists/not found), empty
+
+### Build Status
+- **Build:** SUCCESS (0 errors, 0 warnings)
+- **Tests:** 190 passing (117 domain + 71 application + 2 boilerplate)
+
+### Next Steps
+1. **Phase 6:** Rate limiting + CAPTCHA
+2. **Phase 7:** Email verification + password reset
+3. **Phase 8:** CI/CD & staging deploy

--- a/src/CarCheck.API/Endpoints/FavoriteEndpoints.cs
+++ b/src/CarCheck.API/Endpoints/FavoriteEndpoints.cs
@@ -1,0 +1,57 @@
+using System.Security.Claims;
+using CarCheck.Application.Favorites;
+using CarCheck.Application.Favorites.DTOs;
+
+namespace CarCheck.API.Endpoints;
+
+public static class FavoriteEndpoints
+{
+    public static void MapFavoriteEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/favorites").WithTags("Favorites").RequireAuthorization();
+
+        group.MapGet("/", async (int? page, int? pageSize, FavoriteService favoriteService, ClaimsPrincipal user) =>
+        {
+            var userId = GetUserId(user);
+            if (userId is null) return Results.Unauthorized();
+
+            var result = await favoriteService.GetFavoritesAsync(userId.Value, page ?? 1, pageSize ?? 20);
+            return result.IsSuccess
+                ? Results.Ok(result.Value)
+                : Results.BadRequest(new { error = result.Error });
+        })
+        .WithName("GetFavorites");
+
+        group.MapPost("/", async (AddFavoriteRequest request, FavoriteService favoriteService, ClaimsPrincipal user) =>
+        {
+            var userId = GetUserId(user);
+            if (userId is null) return Results.Unauthorized();
+
+            var result = await favoriteService.AddFavoriteAsync(userId.Value, request);
+            return result.IsSuccess
+                ? Results.Created($"/api/favorites/{result.Value!.CarId}", result.Value)
+                : Results.BadRequest(new { error = result.Error });
+        })
+        .WithName("AddFavorite");
+
+        group.MapDelete("/{carId:guid}", async (Guid carId, FavoriteService favoriteService, ClaimsPrincipal user) =>
+        {
+            var userId = GetUserId(user);
+            if (userId is null) return Results.Unauthorized();
+
+            var result = await favoriteService.RemoveFavoriteAsync(userId.Value, carId);
+            return result.IsSuccess
+                ? Results.Ok(new { message = "Favorite removed." })
+                : Results.NotFound(new { error = result.Error });
+        })
+        .WithName("RemoveFavorite");
+    }
+
+    private static Guid? GetUserId(ClaimsPrincipal user)
+    {
+        var claim = user.FindFirst(ClaimTypes.NameIdentifier)
+            ?? user.FindFirst("sub");
+
+        return claim is not null && Guid.TryParse(claim.Value, out var id) ? id : null;
+    }
+}

--- a/src/CarCheck.API/Endpoints/HistoryEndpoints.cs
+++ b/src/CarCheck.API/Endpoints/HistoryEndpoints.cs
@@ -1,0 +1,32 @@
+using System.Security.Claims;
+using CarCheck.Application.History;
+
+namespace CarCheck.API.Endpoints;
+
+public static class HistoryEndpoints
+{
+    public static void MapHistoryEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/history").WithTags("Search History").RequireAuthorization();
+
+        group.MapGet("/", async (int? page, int? pageSize, SearchHistoryService historyService, ClaimsPrincipal user) =>
+        {
+            var userId = GetUserId(user);
+            if (userId is null) return Results.Unauthorized();
+
+            var result = await historyService.GetHistoryAsync(userId.Value, page ?? 1, pageSize ?? 20);
+            return result.IsSuccess
+                ? Results.Ok(result.Value)
+                : Results.BadRequest(new { error = result.Error });
+        })
+        .WithName("GetSearchHistory");
+    }
+
+    private static Guid? GetUserId(ClaimsPrincipal user)
+    {
+        var claim = user.FindFirst(ClaimTypes.NameIdentifier)
+            ?? user.FindFirst("sub");
+
+        return claim is not null && Guid.TryParse(claim.Value, out var id) ? id : null;
+    }
+}

--- a/src/CarCheck.API/Program.cs
+++ b/src/CarCheck.API/Program.cs
@@ -49,5 +49,7 @@ app.MapGet("/health", () => Results.Ok(new { status = "healthy", timestamp = Dat
 
 app.MapAuthEndpoints();
 app.MapCarEndpoints();
+app.MapHistoryEndpoints();
+app.MapFavoriteEndpoints();
 
 app.Run();

--- a/src/CarCheck.Application/Favorites/DTOs/FavoriteDTOs.cs
+++ b/src/CarCheck.Application/Favorites/DTOs/FavoriteDTOs.cs
@@ -1,0 +1,17 @@
+namespace CarCheck.Application.Favorites.DTOs;
+
+public record AddFavoriteRequest(Guid CarId);
+
+public record FavoriteResponse(
+    Guid Id,
+    Guid CarId,
+    string? RegistrationNumber,
+    string? Brand,
+    string? Model,
+    int? Year,
+    DateTime CreatedAt);
+
+public record FavoritePageResponse(
+    IReadOnlyList<FavoriteResponse> Items,
+    int Page,
+    int PageSize);

--- a/src/CarCheck.Application/Favorites/FavoriteService.cs
+++ b/src/CarCheck.Application/Favorites/FavoriteService.cs
@@ -1,0 +1,80 @@
+using CarCheck.Application.Auth;
+using CarCheck.Application.Favorites.DTOs;
+using CarCheck.Domain.Entities;
+using CarCheck.Domain.Interfaces;
+
+namespace CarCheck.Application.Favorites;
+
+public class FavoriteService
+{
+    private readonly IFavoriteRepository _favoriteRepository;
+    private readonly ICarRepository _carRepository;
+
+    public FavoriteService(
+        IFavoriteRepository favoriteRepository,
+        ICarRepository carRepository)
+    {
+        _favoriteRepository = favoriteRepository;
+        _carRepository = carRepository;
+    }
+
+    public async Task<Result<FavoritePageResponse>> GetFavoritesAsync(
+        Guid userId, int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)
+    {
+        if (page < 1) page = 1;
+        if (pageSize < 1) pageSize = 1;
+        if (pageSize > 100) pageSize = 100;
+
+        var favorites = await _favoriteRepository.GetByUserIdAsync(userId, page, pageSize, cancellationToken);
+
+        var items = new List<FavoriteResponse>();
+        foreach (var fav in favorites)
+        {
+            var car = await _carRepository.GetByIdAsync(fav.CarId, cancellationToken);
+            items.Add(new FavoriteResponse(
+                fav.Id,
+                fav.CarId,
+                car?.RegistrationNumber.Value,
+                car?.Brand,
+                car?.Model,
+                car?.Year,
+                fav.CreatedAt));
+        }
+
+        return Result<FavoritePageResponse>.Success(
+            new FavoritePageResponse(items, page, pageSize));
+    }
+
+    public async Task<Result<FavoriteResponse>> AddFavoriteAsync(
+        Guid userId, AddFavoriteRequest request, CancellationToken cancellationToken = default)
+    {
+        var car = await _carRepository.GetByIdAsync(request.CarId, cancellationToken);
+        if (car is null)
+            return Result<FavoriteResponse>.Failure("Car not found.");
+
+        if (await _favoriteRepository.ExistsAsync(userId, request.CarId, cancellationToken))
+            return Result<FavoriteResponse>.Failure("Car is already in favorites.");
+
+        var favorite = Favorite.Create(userId, request.CarId);
+        await _favoriteRepository.AddAsync(favorite, cancellationToken);
+
+        return Result<FavoriteResponse>.Success(new FavoriteResponse(
+            favorite.Id,
+            favorite.CarId,
+            car.RegistrationNumber.Value,
+            car.Brand,
+            car.Model,
+            car.Year,
+            favorite.CreatedAt));
+    }
+
+    public async Task<Result<bool>> RemoveFavoriteAsync(
+        Guid userId, Guid carId, CancellationToken cancellationToken = default)
+    {
+        if (!await _favoriteRepository.ExistsAsync(userId, carId, cancellationToken))
+            return Result<bool>.Failure("Favorite not found.");
+
+        await _favoriteRepository.RemoveAsync(userId, carId, cancellationToken);
+        return Result<bool>.Success(true);
+    }
+}

--- a/src/CarCheck.Application/History/DTOs/HistoryDTOs.cs
+++ b/src/CarCheck.Application/History/DTOs/HistoryDTOs.cs
@@ -1,0 +1,16 @@
+namespace CarCheck.Application.History.DTOs;
+
+public record SearchHistoryResponse(
+    Guid Id,
+    Guid CarId,
+    string? RegistrationNumber,
+    string? Brand,
+    string? Model,
+    int? Year,
+    DateTime SearchedAt);
+
+public record SearchHistoryPageResponse(
+    IReadOnlyList<SearchHistoryResponse> Items,
+    int Page,
+    int PageSize,
+    int TodayCount);

--- a/src/CarCheck.Application/History/SearchHistoryService.cs
+++ b/src/CarCheck.Application/History/SearchHistoryService.cs
@@ -1,0 +1,47 @@
+using CarCheck.Application.Auth;
+using CarCheck.Application.History.DTOs;
+using CarCheck.Domain.Interfaces;
+
+namespace CarCheck.Application.History;
+
+public class SearchHistoryService
+{
+    private readonly ISearchHistoryRepository _searchHistoryRepository;
+    private readonly ICarRepository _carRepository;
+
+    public SearchHistoryService(
+        ISearchHistoryRepository searchHistoryRepository,
+        ICarRepository carRepository)
+    {
+        _searchHistoryRepository = searchHistoryRepository;
+        _carRepository = carRepository;
+    }
+
+    public async Task<Result<SearchHistoryPageResponse>> GetHistoryAsync(
+        Guid userId, int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)
+    {
+        if (page < 1) page = 1;
+        if (pageSize < 1) pageSize = 1;
+        if (pageSize > 100) pageSize = 100;
+
+        var entries = await _searchHistoryRepository.GetByUserIdAsync(userId, page, pageSize, cancellationToken);
+        var todayCount = await _searchHistoryRepository.GetCountByUserIdTodayAsync(userId, cancellationToken);
+
+        var items = new List<SearchHistoryResponse>();
+        foreach (var entry in entries)
+        {
+            var car = await _carRepository.GetByIdAsync(entry.CarId, cancellationToken);
+            items.Add(new SearchHistoryResponse(
+                entry.Id,
+                entry.CarId,
+                car?.RegistrationNumber.Value,
+                car?.Brand,
+                car?.Model,
+                car?.Year,
+                entry.SearchedAt));
+        }
+
+        return Result<SearchHistoryPageResponse>.Success(
+            new SearchHistoryPageResponse(items, page, pageSize, todayCount));
+    }
+}

--- a/src/CarCheck.Infrastructure/DependencyInjection.cs
+++ b/src/CarCheck.Infrastructure/DependencyInjection.cs
@@ -1,5 +1,7 @@
 using CarCheck.Application.Auth;
 using CarCheck.Application.Cars;
+using CarCheck.Application.Favorites;
+using CarCheck.Application.History;
 using CarCheck.Application.Interfaces;
 using CarCheck.Domain.Interfaces;
 using CarCheck.Infrastructure.Auth;
@@ -48,6 +50,10 @@ public static class DependencyInjection
         // Car services
         services.AddScoped<CarAnalysisEngine>();
         services.AddScoped<CarSearchService>();
+
+        // History & Favorites
+        services.AddScoped<SearchHistoryService>();
+        services.AddScoped<FavoriteService>();
 
         return services;
     }

--- a/tests/CarCheck.Application.Tests/Favorites/FavoriteServiceTests.cs
+++ b/tests/CarCheck.Application.Tests/Favorites/FavoriteServiceTests.cs
@@ -1,0 +1,142 @@
+using CarCheck.Application.Favorites;
+using CarCheck.Application.Favorites.DTOs;
+using CarCheck.Domain.Entities;
+using CarCheck.Domain.Interfaces;
+using NSubstitute;
+
+namespace CarCheck.Application.Tests.Favorites;
+
+public class FavoriteServiceTests
+{
+    private readonly IFavoriteRepository _favoriteRepository;
+    private readonly ICarRepository _carRepository;
+    private readonly FavoriteService _sut;
+
+    public FavoriteServiceTests()
+    {
+        _favoriteRepository = Substitute.For<IFavoriteRepository>();
+        _carRepository = Substitute.For<ICarRepository>();
+        _sut = new FavoriteService(_favoriteRepository, _carRepository);
+    }
+
+    // ===== Get Favorites =====
+
+    [Fact]
+    public async Task GetFavorites_ReturnsPaginatedResults()
+    {
+        var userId = Guid.NewGuid();
+        var car = Car.Create("ABC123", "Volvo", "XC60", 2021, 35000);
+        var favorite = Favorite.Create(userId, car.Id);
+
+        _favoriteRepository.GetByUserIdAsync(userId, 1, 20, Arg.Any<CancellationToken>())
+            .Returns(new List<Favorite> { favorite });
+        _carRepository.GetByIdAsync(car.Id, Arg.Any<CancellationToken>())
+            .Returns(car);
+
+        var result = await _sut.GetFavoritesAsync(userId);
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Value!.Items);
+        Assert.Equal("Volvo", result.Value.Items[0].Brand);
+        Assert.Equal("XC60", result.Value.Items[0].Model);
+    }
+
+    [Fact]
+    public async Task GetFavorites_Empty_ReturnsEmptyPage()
+    {
+        var userId = Guid.NewGuid();
+
+        _favoriteRepository.GetByUserIdAsync(userId, 1, 20, Arg.Any<CancellationToken>())
+            .Returns(new List<Favorite>());
+
+        var result = await _sut.GetFavoritesAsync(userId);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value!.Items);
+    }
+
+    // ===== Add Favorite =====
+
+    [Fact]
+    public async Task AddFavorite_WithValidCar_ReturnsSuccess()
+    {
+        var userId = Guid.NewGuid();
+        var car = Car.Create("DEF456", "BMW", "320d", 2018, 87000);
+
+        _carRepository.GetByIdAsync(car.Id, Arg.Any<CancellationToken>())
+            .Returns(car);
+        _favoriteRepository.ExistsAsync(userId, car.Id, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var result = await _sut.AddFavoriteAsync(userId, new AddFavoriteRequest(car.Id));
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("BMW", result.Value!.Brand);
+        Assert.Equal(car.Id, result.Value.CarId);
+        await _favoriteRepository.Received(1).AddAsync(Arg.Any<Favorite>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AddFavorite_CarNotFound_ReturnsFailure()
+    {
+        var userId = Guid.NewGuid();
+        var carId = Guid.NewGuid();
+
+        _carRepository.GetByIdAsync(carId, Arg.Any<CancellationToken>())
+            .Returns((Car?)null);
+
+        var result = await _sut.AddFavoriteAsync(userId, new AddFavoriteRequest(carId));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Car not found.", result.Error);
+    }
+
+    [Fact]
+    public async Task AddFavorite_AlreadyExists_ReturnsFailure()
+    {
+        var userId = Guid.NewGuid();
+        var car = Car.Create("ABC123", "Volvo", "XC60", 2021, 35000);
+
+        _carRepository.GetByIdAsync(car.Id, Arg.Any<CancellationToken>())
+            .Returns(car);
+        _favoriteRepository.ExistsAsync(userId, car.Id, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var result = await _sut.AddFavoriteAsync(userId, new AddFavoriteRequest(car.Id));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Car is already in favorites.", result.Error);
+    }
+
+    // ===== Remove Favorite =====
+
+    [Fact]
+    public async Task RemoveFavorite_Exists_ReturnsSuccess()
+    {
+        var userId = Guid.NewGuid();
+        var carId = Guid.NewGuid();
+
+        _favoriteRepository.ExistsAsync(userId, carId, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var result = await _sut.RemoveFavoriteAsync(userId, carId);
+
+        Assert.True(result.IsSuccess);
+        await _favoriteRepository.Received(1).RemoveAsync(userId, carId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RemoveFavorite_NotFound_ReturnsFailure()
+    {
+        var userId = Guid.NewGuid();
+        var carId = Guid.NewGuid();
+
+        _favoriteRepository.ExistsAsync(userId, carId, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var result = await _sut.RemoveFavoriteAsync(userId, carId);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Favorite not found.", result.Error);
+    }
+}

--- a/tests/CarCheck.Application.Tests/History/SearchHistoryServiceTests.cs
+++ b/tests/CarCheck.Application.Tests/History/SearchHistoryServiceTests.cs
@@ -1,0 +1,100 @@
+using CarCheck.Application.History;
+using CarCheck.Domain.Entities;
+using CarCheck.Domain.Interfaces;
+using NSubstitute;
+
+namespace CarCheck.Application.Tests.History;
+
+public class SearchHistoryServiceTests
+{
+    private readonly ISearchHistoryRepository _searchHistoryRepository;
+    private readonly ICarRepository _carRepository;
+    private readonly SearchHistoryService _sut;
+
+    public SearchHistoryServiceTests()
+    {
+        _searchHistoryRepository = Substitute.For<ISearchHistoryRepository>();
+        _carRepository = Substitute.For<ICarRepository>();
+        _sut = new SearchHistoryService(_searchHistoryRepository, _carRepository);
+    }
+
+    [Fact]
+    public async Task GetHistory_ReturnsPagedResults()
+    {
+        var userId = Guid.NewGuid();
+        var car = Car.Create("ABC123", "Volvo", "XC60", 2021, 35000);
+        var entry = SearchHistory.Create(userId, car.Id);
+
+        _searchHistoryRepository.GetByUserIdAsync(userId, 1, 20, Arg.Any<CancellationToken>())
+            .Returns(new List<SearchHistory> { entry });
+        _searchHistoryRepository.GetCountByUserIdTodayAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(3);
+        _carRepository.GetByIdAsync(car.Id, Arg.Any<CancellationToken>())
+            .Returns(car);
+
+        var result = await _sut.GetHistoryAsync(userId);
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Value!.Items);
+        Assert.Equal("Volvo", result.Value.Items[0].Brand);
+        Assert.Equal("ABC123", result.Value.Items[0].RegistrationNumber);
+        Assert.Equal(3, result.Value.TodayCount);
+        Assert.Equal(1, result.Value.Page);
+    }
+
+    [Fact]
+    public async Task GetHistory_WithDeletedCar_ReturnsNullFields()
+    {
+        var userId = Guid.NewGuid();
+        var carId = Guid.NewGuid();
+        var entry = SearchHistory.Create(userId, carId);
+
+        _searchHistoryRepository.GetByUserIdAsync(userId, 1, 20, Arg.Any<CancellationToken>())
+            .Returns(new List<SearchHistory> { entry });
+        _searchHistoryRepository.GetCountByUserIdTodayAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(1);
+        _carRepository.GetByIdAsync(carId, Arg.Any<CancellationToken>())
+            .Returns((Car?)null);
+
+        var result = await _sut.GetHistoryAsync(userId);
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Value!.Items);
+        Assert.Null(result.Value.Items[0].Brand);
+        Assert.Null(result.Value.Items[0].RegistrationNumber);
+    }
+
+    [Fact]
+    public async Task GetHistory_EmptyResults_ReturnsEmptyPage()
+    {
+        var userId = Guid.NewGuid();
+
+        _searchHistoryRepository.GetByUserIdAsync(userId, 1, 20, Arg.Any<CancellationToken>())
+            .Returns(new List<SearchHistory>());
+        _searchHistoryRepository.GetCountByUserIdTodayAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        var result = await _sut.GetHistoryAsync(userId);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value!.Items);
+        Assert.Equal(0, result.Value.TodayCount);
+    }
+
+    [Fact]
+    public async Task GetHistory_ClampsPageSize()
+    {
+        var userId = Guid.NewGuid();
+
+        _searchHistoryRepository.GetByUserIdAsync(userId, 1, 100, Arg.Any<CancellationToken>())
+            .Returns(new List<SearchHistory>());
+        _searchHistoryRepository.GetCountByUserIdTodayAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        var result = await _sut.GetHistoryAsync(userId, page: 0, pageSize: 999);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(100, result.Value!.PageSize);
+        Assert.Equal(1, result.Value.Page);
+    }
+}


### PR DESCRIPTION
## Summary
- **Search history** endpoint with pagination, car detail enrichment, and daily search count
- **Favorites** CRUD: add, remove, list with car detail enrichment and duplicate prevention
- **4 new API endpoints**: `GET /api/history`, `GET/POST /api/favorites`, `DELETE /api/favorites/{carId}`
- **11 new unit tests** — 190 total passing

## New Files
- `src/CarCheck.Application/History/SearchHistoryService.cs` — paginated history service
- `src/CarCheck.Application/Favorites/FavoriteService.cs` — favorites add/remove/list
- `src/CarCheck.API/Endpoints/HistoryEndpoints.cs` — history API
- `src/CarCheck.API/Endpoints/FavoriteEndpoints.cs` — favorites API

## Test plan
- [x] All 190 tests passing
- [x] Build: 0 errors, 0 warnings
- [ ] Manual test: search → check history → add favorite → list favorites → remove favorite

🤖 Generated with [Claude Code](https://claude.com/claude-code)