### PR TITLE
feat: Extend car analysis from 5 to 12 factors

### DIFF
--- a/frontend/src/types/car.types.ts
+++ b/frontend/src/types/car.types.ts
@@ -35,4 +35,11 @@ export interface AnalysisBreakdown {
   insuranceScore: number
   recallScore: number
   inspectionScore: number
+  debtFinanceScore: number
+  serviceHistoryScore: number
+  drivetrainScore: number
+  ownerHistoryScore: number
+  marketValueScore: number
+  environmentScore: number
+  theftSecurityScore: number
 }

--- a/src/CarCheck.Application/Cars/CarAnalysisEngine.cs
+++ b/src/CarCheck.Application/Cars/CarAnalysisEngine.cs
@@ -6,11 +6,18 @@ namespace CarCheck.Application.Cars;
 public class CarAnalysisEngine
 {
     // Weights for each scoring category (must sum to 1.0)
-    private const decimal AgeWeight = 0.25m;
-    private const decimal MileageWeight = 0.25m;
-    private const decimal InsuranceWeight = 0.20m;
-    private const decimal RecallWeight = 0.15m;
-    private const decimal InspectionWeight = 0.15m;
+    private const decimal DebtFinanceWeight = 0.15m;
+    private const decimal AgeWeight = 0.12m;
+    private const decimal MileageWeight = 0.12m;
+    private const decimal InspectionWeight = 0.10m;
+    private const decimal InsuranceWeight = 0.09m;
+    private const decimal ServiceHistoryWeight = 0.08m;
+    private const decimal DrivetrainWeight = 0.08m;
+    private const decimal RecallWeight = 0.06m;
+    private const decimal OwnerHistoryWeight = 0.05m;
+    private const decimal MarketValueWeight = 0.05m;
+    private const decimal EnvironmentWeight = 0.05m;
+    private const decimal TheftSecurityWeight = 0.05m;
 
     public (decimal Score, string Recommendation, AnalysisBreakdown Breakdown) Analyze(CarDataResult data)
     {
@@ -19,13 +26,27 @@ public class CarAnalysisEngine
         var insuranceScore = CalculateInsuranceScore(data.InsuranceIncidents);
         var recallScore = CalculateRecallScore(data.ManufacturerRecalls);
         var inspectionScore = CalculateInspectionScore(data.LastInspectionDate, data.InspectionPassed);
+        var debtFinanceScore = CalculateDebtFinanceScore(data.HasPurchaseBlock, data.OutstandingDebtSek, data.TaxDebtSek);
+        var serviceHistoryScore = CalculateServiceHistoryScore(data.ServiceCount, data.Year, data.CompleteServiceHistory, data.AuthorizedServiceUsed, data.LastServiceDate);
+        var drivetrainScore = CalculateDrivetrainScore(data.ReliabilityRating, data.CommonIssuesCount, data.AverageRepairCostSek);
+        var ownerHistoryScore = CalculateOwnerHistoryScore(data.NumberOfOwners, data.IsCompanyOwned, data.FirstRegistrationDate);
+        var marketValueScore = CalculateMarketValueScore(data.MarketValueSek, data.AverageMarketPriceSek, data.DepreciationRatePercent);
+        var environmentScore = CalculateEnvironmentScore(data.EuroClass, data.Co2EmissionsGPerKm, data.AnnualTaxSek, data.FuelType);
+        var theftSecurityScore = CalculateTheftSecurityScore(data.TheftRiskCategory, data.EuroNcapRating, data.HasAlarmSystem);
 
         var totalScore = Math.Round(
             ageScore * AgeWeight +
             mileageScore * MileageWeight +
             insuranceScore * InsuranceWeight +
             recallScore * RecallWeight +
-            inspectionScore * InspectionWeight,
+            inspectionScore * InspectionWeight +
+            debtFinanceScore * DebtFinanceWeight +
+            serviceHistoryScore * ServiceHistoryWeight +
+            drivetrainScore * DrivetrainWeight +
+            ownerHistoryScore * OwnerHistoryWeight +
+            marketValueScore * MarketValueWeight +
+            environmentScore * EnvironmentWeight +
+            theftSecurityScore * TheftSecurityWeight,
             1);
 
         totalScore = Math.Clamp(totalScore, 0, 100);
@@ -36,10 +57,19 @@ public class CarAnalysisEngine
             Math.Round(mileageScore, 1),
             Math.Round(insuranceScore, 1),
             Math.Round(recallScore, 1),
-            Math.Round(inspectionScore, 1));
+            Math.Round(inspectionScore, 1),
+            Math.Round(debtFinanceScore, 1),
+            Math.Round(serviceHistoryScore, 1),
+            Math.Round(drivetrainScore, 1),
+            Math.Round(ownerHistoryScore, 1),
+            Math.Round(marketValueScore, 1),
+            Math.Round(environmentScore, 1),
+            Math.Round(theftSecurityScore, 1));
 
         return (totalScore, recommendation, breakdown);
     }
+
+    // ===== Existing factors (unchanged logic) =====
 
     internal static decimal CalculateAgeScore(int year)
     {
@@ -122,6 +152,234 @@ public class CarAnalysisEngine
             recencyScore *= 0.5m;
 
         return recencyScore;
+    }
+
+    // ===== New factors =====
+
+    internal static decimal CalculateDebtFinanceScore(bool? hasPurchaseBlock, decimal? outstandingDebtSek, decimal? taxDebtSek)
+    {
+        if (hasPurchaseBlock == true) return 0; // Deal-breaker
+
+        if (outstandingDebtSek is null && taxDebtSek is null && hasPurchaseBlock is null) return 50; // Fallback
+
+        var score = outstandingDebtSek switch
+        {
+            null => 50m,
+            0 => 100m,
+            <= 20_000 => 80m,
+            <= 50_000 => 60m,
+            <= 100_000 => 40m,
+            <= 200_000 => 20m,
+            _ => 5m
+        };
+
+        if (taxDebtSek is > 0)
+            score -= 15m;
+
+        return Math.Clamp(score, 0, 100);
+    }
+
+    internal static decimal CalculateOwnerHistoryScore(int? numberOfOwners, bool? isCompanyOwned, DateTime? firstRegistrationDate)
+    {
+        if (numberOfOwners is null && isCompanyOwned is null && firstRegistrationDate is null) return 60; // Fallback
+
+        var score = numberOfOwners switch
+        {
+            null => 60m,
+            1 => 100m,
+            2 => 85m,
+            3 => 65m,
+            4 => 45m,
+            _ => 25m
+        };
+
+        if (isCompanyOwned == true)
+            score -= 10m;
+
+        // If sat unsold > 1 year (gap between first registration and now vs expected ownership)
+        if (firstRegistrationDate is not null)
+        {
+            var yearsSinceFirstReg = (DateTime.UtcNow - firstRegistrationDate.Value).TotalDays / 365.25;
+            if (yearsSinceFirstReg > 1 && numberOfOwners is 0 or null)
+                score -= 5m;
+        }
+
+        return Math.Clamp(score, 0, 100);
+    }
+
+    internal static decimal CalculateEnvironmentScore(string? euroClass, int? co2EmissionsGPerKm, decimal? annualTaxSek, string? fuelType)
+    {
+        if (euroClass is null && co2EmissionsGPerKm is null && annualTaxSek is null) return 60; // Fallback
+
+        // Electric vehicles get top score
+        if (fuelType?.Equals("Electric", StringComparison.OrdinalIgnoreCase) == true)
+            return 100m;
+
+        var score = (euroClass?.ToUpperInvariant()) switch
+        {
+            "EURO 7" or "EURO 6D" => 100m,
+            "EURO 6" => 85m,
+            "EURO 5" => 60m,
+            "EURO 4" => 40m,
+            null => 60m,
+            _ => 20m // Euro 3 or below
+        };
+
+        // CO2 modifier
+        if (co2EmissionsGPerKm is not null)
+        {
+            score += co2EmissionsGPerKm.Value switch
+            {
+                <= 50 => 0m,
+                <= 120 => -5m,
+                <= 180 => -10m,
+                _ => -20m
+            };
+        }
+
+        // Tax modifier
+        if (annualTaxSek is not null)
+        {
+            score += annualTaxSek.Value switch
+            {
+                <= 500 => 0m,
+                <= 2_000 => -5m,
+                <= 5_000 => -10m,
+                _ => -15m
+            };
+        }
+
+        return Math.Clamp(score, 0, 100);
+    }
+
+    internal static decimal CalculateMarketValueScore(decimal? marketValueSek, decimal? averageMarketPriceSek, decimal? depreciationRatePercent)
+    {
+        if (marketValueSek is null || averageMarketPriceSek is null || averageMarketPriceSek == 0) return 50; // Fallback
+
+        var priceRatio = marketValueSek.Value / averageMarketPriceSek.Value;
+
+        var score = priceRatio switch
+        {
+            <= 0.80m => 95m,
+            <= 0.95m => 85m,
+            <= 1.05m => 75m,
+            <= 1.15m => 55m,
+            _ => 35m
+        };
+
+        // Depreciation modifier
+        if (depreciationRatePercent is not null)
+        {
+            score += depreciationRatePercent.Value switch
+            {
+                <= 8m => 5m,
+                <= 15m => 0m,
+                <= 22m => -5m,
+                _ => -10m
+            };
+        }
+
+        return Math.Clamp(score, 0, 100);
+    }
+
+    internal static decimal CalculateServiceHistoryScore(int? serviceCount, int year, bool? completeServiceHistory, bool? authorizedServiceUsed, DateTime? lastServiceDate)
+    {
+        if (serviceCount is null && completeServiceHistory is null && lastServiceDate is null) return 40; // Fallback
+
+        var age = Math.Max(1, DateTime.UtcNow.Year - year);
+
+        // Service frequency vs age
+        var ratio = serviceCount is not null ? (decimal)serviceCount.Value / age : 0m;
+
+        var score = ratio switch
+        {
+            >= 1.0m => 90m,
+            >= 0.75m => 70m,
+            >= 0.50m => 50m,
+            >= 0.25m => 30m,
+            _ => 15m
+        };
+
+        if (completeServiceHistory == true)
+            score += 10m;
+
+        if (authorizedServiceUsed == true)
+            score += 5m;
+
+        // Penalty if last service was >24 months ago
+        if (lastServiceDate is not null)
+        {
+            var monthsSinceService = (int)(DateTime.UtcNow - lastServiceDate.Value).TotalDays / 30;
+            if (monthsSinceService > 24)
+                score -= 10m;
+        }
+
+        return Math.Clamp(score, 0, 100);
+    }
+
+    internal static decimal CalculateTheftSecurityScore(string? theftRiskCategory, int? euroNcapRating, bool? hasAlarmSystem)
+    {
+        if (theftRiskCategory is null && euroNcapRating is null && hasAlarmSystem is null) return 60; // Fallback
+
+        var riskScore = (theftRiskCategory?.ToUpperInvariant()) switch
+        {
+            "LOW" => 100m,
+            "MEDIUM" => 65m,
+            "HIGH" => 30m,
+            _ => 60m
+        };
+
+        var ncapScore = euroNcapRating switch
+        {
+            5 => 100m,
+            4 => 80m,
+            3 => 60m,
+            2 => 40m,
+            1 => 20m,
+            _ => 60m
+        };
+
+        // 50/50 weighting between theft risk and NCAP
+        var score = (riskScore + ncapScore) / 2m;
+
+        if (hasAlarmSystem == true)
+            score += 5m;
+
+        return Math.Clamp(score, 0, 100);
+    }
+
+    internal static decimal CalculateDrivetrainScore(decimal? reliabilityRating, int? commonIssuesCount, decimal? averageRepairCostSek)
+    {
+        if (reliabilityRating is null && commonIssuesCount is null && averageRepairCostSek is null) return 55; // Fallback
+
+        var score = reliabilityRating ?? 55m;
+
+        // Common issues modifier
+        if (commonIssuesCount is not null)
+        {
+            score += commonIssuesCount.Value switch
+            {
+                0 => 0m,
+                <= 2 => -5m,
+                <= 4 => -10m,
+                <= 6 => -15m,
+                _ => -25m
+            };
+        }
+
+        // Repair cost modifier
+        if (averageRepairCostSek is not null)
+        {
+            score += averageRepairCostSek.Value switch
+            {
+                <= 3_000 => 0m,
+                <= 8_000 => -5m,
+                <= 15_000 => -10m,
+                _ => -15m
+            };
+        }
+
+        return Math.Clamp(score, 0, 100);
     }
 
     private static string GenerateRecommendation(decimal score) => score switch

--- a/src/CarCheck.Application/Cars/CarSearchService.cs
+++ b/src/CarCheck.Application/Cars/CarSearchService.cs
@@ -183,7 +183,7 @@ public class CarSearchService
             car.Year,
             analysis.Score,
             analysis.Recommendation,
-            breakdown ?? new AnalysisBreakdown(0, 0, 0, 0, 0),
+            breakdown ?? new AnalysisBreakdown(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
             analysis.CreatedAt);
     }
 }

--- a/src/CarCheck.Application/Cars/DTOs/CarDTOs.cs
+++ b/src/CarCheck.Application/Cars/DTOs/CarDTOs.cs
@@ -31,4 +31,11 @@ public record AnalysisBreakdown(
     decimal MileageScore,
     decimal InsuranceScore,
     decimal RecallScore,
-    decimal InspectionScore);
+    decimal InspectionScore,
+    decimal DebtFinanceScore,
+    decimal ServiceHistoryScore,
+    decimal DrivetrainScore,
+    decimal OwnerHistoryScore,
+    decimal MarketValueScore,
+    decimal EnvironmentScore,
+    decimal TheftSecurityScore);

--- a/src/CarCheck.Application/Interfaces/ICarDataProvider.cs
+++ b/src/CarCheck.Application/Interfaces/ICarDataProvider.cs
@@ -18,4 +18,41 @@ public record CarDataResult(
     int? ManufacturerRecalls,
     DateTime? LastInspectionDate,
     bool? InspectionPassed,
-    decimal? MarketValueSek);
+    decimal? MarketValueSek)
+{
+    // Owner history
+    public int? NumberOfOwners { get; init; }
+    public bool? IsCompanyOwned { get; init; }
+    public DateTime? FirstRegistrationDate { get; init; }
+
+    // Debt & finance
+    public decimal? OutstandingDebtSek { get; init; }
+    public decimal? TaxDebtSek { get; init; }
+    public bool? HasPurchaseBlock { get; init; }
+
+    // Environment & tax
+    public string? EuroClass { get; init; }
+    public int? Co2EmissionsGPerKm { get; init; }
+    public decimal? AnnualTaxSek { get; init; }
+    public bool? BonusMalusApplies { get; init; }
+
+    // Market value (MarketValueSek already exists as constructor param)
+    public decimal? AverageMarketPriceSek { get; init; }
+    public decimal? DepreciationRatePercent { get; init; }
+
+    // Service history
+    public int? ServiceCount { get; init; }
+    public bool? AuthorizedServiceUsed { get; init; }
+    public DateTime? LastServiceDate { get; init; }
+    public bool? CompleteServiceHistory { get; init; }
+
+    // Theft & security
+    public string? TheftRiskCategory { get; init; }
+    public int? EuroNcapRating { get; init; }
+    public bool? HasAlarmSystem { get; init; }
+
+    // Drivetrain & reliability
+    public decimal? ReliabilityRating { get; init; }
+    public int? CommonIssuesCount { get; init; }
+    public decimal? AverageRepairCostSek { get; init; }
+}

--- a/src/CarCheck.Infrastructure/External/MockCarDataProvider.cs
+++ b/src/CarCheck.Infrastructure/External/MockCarDataProvider.cs
@@ -15,28 +15,72 @@ public class MockCarDataProvider : ICarDataProvider
             "Diesel", 235, "Black",
             InsuranceIncidents: 0, ManufacturerRecalls: 0,
             LastInspectionDate: DateTime.UtcNow.AddMonths(-3), InspectionPassed: true,
-            MarketValueSek: 385000m),
+            MarketValueSek: 385000m)
+        {
+            NumberOfOwners = 1, IsCompanyOwned = false,
+            FirstRegistrationDate = new DateTime(2021, 3, 15, 0, 0, 0, DateTimeKind.Utc),
+            OutstandingDebtSek = 0m, TaxDebtSek = 0m, HasPurchaseBlock = false,
+            EuroClass = "Euro 6d", Co2EmissionsGPerKm = 149, AnnualTaxSek = 1_891m, BonusMalusApplies = true,
+            AverageMarketPriceSek = 395000m, DepreciationRatePercent = 12m,
+            ServiceCount = 5, AuthorizedServiceUsed = true,
+            LastServiceDate = DateTime.UtcNow.AddMonths(-4), CompleteServiceHistory = true,
+            TheftRiskCategory = "Low", EuroNcapRating = 5, HasAlarmSystem = true,
+            ReliabilityRating = 85m, CommonIssuesCount = 1, AverageRepairCostSek = 4500m
+        },
 
         ["DEF456"] = new CarDataResult(
             "DEF456", "BMW", "320d", 2018, 87000,
             "Diesel", 190, "White",
             InsuranceIncidents: 1, ManufacturerRecalls: 1,
             LastInspectionDate: DateTime.UtcNow.AddMonths(-8), InspectionPassed: true,
-            MarketValueSek: 215000m),
+            MarketValueSek: 215000m)
+        {
+            NumberOfOwners = 2, IsCompanyOwned = false,
+            FirstRegistrationDate = new DateTime(2018, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            OutstandingDebtSek = 45_000m, TaxDebtSek = 0m, HasPurchaseBlock = false,
+            EuroClass = "Euro 6", Co2EmissionsGPerKm = 119, AnnualTaxSek = 1_360m, BonusMalusApplies = true,
+            AverageMarketPriceSek = 230000m, DepreciationRatePercent = 15m,
+            ServiceCount = 6, AuthorizedServiceUsed = true,
+            LastServiceDate = DateTime.UtcNow.AddMonths(-6), CompleteServiceHistory = true,
+            TheftRiskCategory = "Medium", EuroNcapRating = 5, HasAlarmSystem = true,
+            ReliabilityRating = 72m, CommonIssuesCount = 3, AverageRepairCostSek = 8500m
+        },
 
         ["GHI789"] = new CarDataResult(
             "GHI789", "Toyota", "Corolla", 2015, 142000,
             "Petrol", 132, "Silver",
             InsuranceIncidents: 2, ManufacturerRecalls: 0,
             LastInspectionDate: DateTime.UtcNow.AddMonths(-14), InspectionPassed: false,
-            MarketValueSek: 95000m),
+            MarketValueSek: 95000m)
+        {
+            NumberOfOwners = 3, IsCompanyOwned = false,
+            FirstRegistrationDate = new DateTime(2015, 1, 20, 0, 0, 0, DateTimeKind.Utc),
+            OutstandingDebtSek = 0m, TaxDebtSek = 0m, HasPurchaseBlock = false,
+            EuroClass = "Euro 5", Co2EmissionsGPerKm = 135, AnnualTaxSek = 1_006m, BonusMalusApplies = false,
+            AverageMarketPriceSek = 105000m, DepreciationRatePercent = 10m,
+            ServiceCount = 7, AuthorizedServiceUsed = false,
+            LastServiceDate = DateTime.UtcNow.AddMonths(-18), CompleteServiceHistory = false,
+            TheftRiskCategory = "Low", EuroNcapRating = 4, HasAlarmSystem = false,
+            ReliabilityRating = 90m, CommonIssuesCount = 1, AverageRepairCostSek = 2500m
+        },
 
         ["JKL012"] = new CarDataResult(
             "JKL012", "Tesla", "Model 3", 2023, 12000,
             "Electric", 283, "Red",
             InsuranceIncidents: 0, ManufacturerRecalls: 2,
             LastInspectionDate: DateTime.UtcNow.AddMonths(-1), InspectionPassed: true,
-            MarketValueSek: 420000m),
+            MarketValueSek: 420000m)
+        {
+            NumberOfOwners = 1, IsCompanyOwned = true,
+            FirstRegistrationDate = new DateTime(2023, 9, 10, 0, 0, 0, DateTimeKind.Utc),
+            OutstandingDebtSek = 120_000m, TaxDebtSek = 0m, HasPurchaseBlock = false,
+            EuroClass = "Euro 6d", Co2EmissionsGPerKm = 0, AnnualTaxSek = 360m, BonusMalusApplies = true,
+            AverageMarketPriceSek = 450000m, DepreciationRatePercent = 20m,
+            ServiceCount = 3, AuthorizedServiceUsed = true,
+            LastServiceDate = DateTime.UtcNow.AddMonths(-2), CompleteServiceHistory = true,
+            TheftRiskCategory = "Medium", EuroNcapRating = 5, HasAlarmSystem = true,
+            ReliabilityRating = 75m, CommonIssuesCount = 2, AverageRepairCostSek = 12000m
+        },
 
         ["MNO345"] = new CarDataResult(
             "MNO345", "Volkswagen", "Golf", 2010, 245000,
@@ -44,6 +88,17 @@ public class MockCarDataProvider : ICarDataProvider
             InsuranceIncidents: 3, ManufacturerRecalls: 1,
             LastInspectionDate: DateTime.UtcNow.AddMonths(-26), InspectionPassed: false,
             MarketValueSek: 42000m)
+        {
+            NumberOfOwners = 5, IsCompanyOwned = false,
+            FirstRegistrationDate = new DateTime(2010, 4, 5, 0, 0, 0, DateTimeKind.Utc),
+            OutstandingDebtSek = 0m, TaxDebtSek = 3500m, HasPurchaseBlock = false,
+            EuroClass = "Euro 4", Co2EmissionsGPerKm = 169, AnnualTaxSek = 1_478m, BonusMalusApplies = false,
+            AverageMarketPriceSek = 38000m, DepreciationRatePercent = 8m,
+            ServiceCount = 4, AuthorizedServiceUsed = false,
+            LastServiceDate = DateTime.UtcNow.AddMonths(-30), CompleteServiceHistory = false,
+            TheftRiskCategory = "High", EuroNcapRating = 3, HasAlarmSystem = false,
+            ReliabilityRating = 55m, CommonIssuesCount = 6, AverageRepairCostSek = 9000m
+        }
     };
 
     public Task<CarDataResult?> FetchByRegistrationAsync(string registrationNumber, CancellationToken cancellationToken = default)

--- a/tests/CarCheck.Application.Tests/Cars/CarAnalysisEngineTests.cs
+++ b/tests/CarCheck.Application.Tests/Cars/CarAnalysisEngineTests.cs
@@ -43,7 +43,6 @@ public class CarAnalysisEngineTests
     [Fact]
     public void CalculateMileageScore_WithCurrentYearCar_DoesNotDivideByZero()
     {
-        // Year = current year means age=0, but we use Math.Max(1, age)
         var score = CarAnalysisEngine.CalculateMileageScore(5000, DateTime.UtcNow.Year);
         Assert.True(score > 0);
     }
@@ -120,17 +119,311 @@ public class CarAnalysisEngineTests
         Assert.Equal(50, score);
     }
 
+    // ===== Debt & Finance Score =====
+
+    [Fact]
+    public void CalculateDebtFinanceScore_PurchaseBlock_ReturnsZero()
+    {
+        var score = CarAnalysisEngine.CalculateDebtFinanceScore(true, 0, 0);
+        Assert.Equal(0, score);
+    }
+
+    [Fact]
+    public void CalculateDebtFinanceScore_NoDebt_Returns100()
+    {
+        var score = CarAnalysisEngine.CalculateDebtFinanceScore(false, 0, 0);
+        Assert.Equal(100, score);
+    }
+
+    [Theory]
+    [InlineData(0, 100)]
+    [InlineData(15000, 80)]
+    [InlineData(40000, 60)]
+    [InlineData(80000, 40)]
+    [InlineData(150000, 20)]
+    [InlineData(300000, 5)]
+    public void CalculateDebtFinanceScore_ByDebtLevel_ReturnsExpected(decimal debt, decimal expected)
+    {
+        var score = CarAnalysisEngine.CalculateDebtFinanceScore(false, debt, 0);
+        Assert.Equal(expected, score);
+    }
+
+    [Fact]
+    public void CalculateDebtFinanceScore_WithTaxDebt_DeductsFifteen()
+    {
+        var score = CarAnalysisEngine.CalculateDebtFinanceScore(false, 0, 5000);
+        Assert.Equal(85, score); // 100 - 15
+    }
+
+    [Fact]
+    public void CalculateDebtFinanceScore_AllNull_ReturnsFallback()
+    {
+        var score = CarAnalysisEngine.CalculateDebtFinanceScore(null, null, null);
+        Assert.Equal(50, score);
+    }
+
+    // ===== Owner History Score =====
+
+    [Theory]
+    [InlineData(1, 100)]
+    [InlineData(2, 85)]
+    [InlineData(3, 65)]
+    [InlineData(4, 45)]
+    [InlineData(6, 25)]
+    public void CalculateOwnerHistoryScore_ByOwnerCount_ReturnsExpected(int owners, decimal expected)
+    {
+        var score = CarAnalysisEngine.CalculateOwnerHistoryScore(owners, false, null);
+        Assert.Equal(expected, score);
+    }
+
+    [Fact]
+    public void CalculateOwnerHistoryScore_CompanyOwned_DeductsTen()
+    {
+        var score = CarAnalysisEngine.CalculateOwnerHistoryScore(1, true, null);
+        Assert.Equal(90, score); // 100 - 10
+    }
+
+    [Fact]
+    public void CalculateOwnerHistoryScore_AllNull_ReturnsFallback()
+    {
+        var score = CarAnalysisEngine.CalculateOwnerHistoryScore(null, null, null);
+        Assert.Equal(60, score);
+    }
+
+    [Fact]
+    public void CalculateOwnerHistoryScore_UnsoldOverOneYear_DeductsFive()
+    {
+        // No owners, registered >1 year ago => -5
+        var score = CarAnalysisEngine.CalculateOwnerHistoryScore(null, false, DateTime.UtcNow.AddYears(-2));
+        Assert.Equal(55, score); // 60 (null owners) - 5
+    }
+
+    [Fact]
+    public void CalculateOwnerHistoryScore_ClampsToZero()
+    {
+        // 6 owners (25) + company owned (-10) = 15
+        var score = CarAnalysisEngine.CalculateOwnerHistoryScore(6, true, null);
+        Assert.Equal(15, score);
+    }
+
+    // ===== Environment Score =====
+
+    [Theory]
+    [InlineData("Euro 6d", 100)]
+    [InlineData("Euro 7", 100)]
+    [InlineData("Euro 6", 85)]
+    [InlineData("Euro 5", 60)]
+    [InlineData("Euro 4", 40)]
+    [InlineData("Euro 3", 20)]
+    public void CalculateEnvironmentScore_ByEuroClass_ReturnsExpected(string euroClass, decimal expected)
+    {
+        var score = CarAnalysisEngine.CalculateEnvironmentScore(euroClass, null, null, "Diesel");
+        Assert.Equal(expected, score);
+    }
+
+    [Fact]
+    public void CalculateEnvironmentScore_Electric_Returns100()
+    {
+        var score = CarAnalysisEngine.CalculateEnvironmentScore("Euro 6d", 0, 360, "Electric");
+        Assert.Equal(100, score);
+    }
+
+    [Fact]
+    public void CalculateEnvironmentScore_HighCo2_DeductsPoints()
+    {
+        // Euro 6 (85) + CO2 > 180 (-20) = 65
+        var score = CarAnalysisEngine.CalculateEnvironmentScore("Euro 6", 200, null, "Diesel");
+        Assert.Equal(65, score);
+    }
+
+    [Fact]
+    public void CalculateEnvironmentScore_HighTax_DeductsPoints()
+    {
+        // Euro 6 (85) + Tax > 5000 (-15) = 70
+        var score = CarAnalysisEngine.CalculateEnvironmentScore("Euro 6", null, 6000, "Diesel");
+        Assert.Equal(70, score);
+    }
+
+    [Fact]
+    public void CalculateEnvironmentScore_AllNull_ReturnsFallback()
+    {
+        var score = CarAnalysisEngine.CalculateEnvironmentScore(null, null, null, "Petrol");
+        Assert.Equal(60, score);
+    }
+
+    // ===== Market Value Score =====
+
+    [Fact]
+    public void CalculateMarketValueScore_GoodDeal_ReturnsHigh()
+    {
+        // Price ratio 0.75 => 95
+        var score = CarAnalysisEngine.CalculateMarketValueScore(150000, 200000, null);
+        Assert.Equal(95, score);
+    }
+
+    [Fact]
+    public void CalculateMarketValueScore_FairPrice_ReturnsMid()
+    {
+        // Price ratio 1.0 => 75
+        var score = CarAnalysisEngine.CalculateMarketValueScore(200000, 200000, null);
+        Assert.Equal(75, score);
+    }
+
+    [Fact]
+    public void CalculateMarketValueScore_Overpriced_ReturnsLow()
+    {
+        // Price ratio 1.2 => 35
+        var score = CarAnalysisEngine.CalculateMarketValueScore(240000, 200000, null);
+        Assert.Equal(35, score);
+    }
+
+    [Fact]
+    public void CalculateMarketValueScore_LowDepreciation_AddsBonus()
+    {
+        // Price ratio 1.0 (75) + depr <=8% (+5) = 80
+        var score = CarAnalysisEngine.CalculateMarketValueScore(200000, 200000, 7);
+        Assert.Equal(80, score);
+    }
+
+    [Fact]
+    public void CalculateMarketValueScore_HighDepreciation_DeductsPoints()
+    {
+        // Price ratio 1.0 (75) + depr >22% (-10) = 65
+        var score = CarAnalysisEngine.CalculateMarketValueScore(200000, 200000, 25);
+        Assert.Equal(65, score);
+    }
+
+    [Fact]
+    public void CalculateMarketValueScore_NullData_ReturnsFallback()
+    {
+        var score = CarAnalysisEngine.CalculateMarketValueScore(null, null, null);
+        Assert.Equal(50, score);
+    }
+
+    // ===== Service History Score =====
+
+    [Fact]
+    public void CalculateServiceHistoryScore_ExcellentService_ReturnsHigh()
+    {
+        // 5 services / 5 year age = ratio 1.0 => 90, +10 complete, +5 authorized = 100 (clamped)
+        var score = CarAnalysisEngine.CalculateServiceHistoryScore(5, 2021, true, true, DateTime.UtcNow.AddMonths(-6));
+        Assert.Equal(100, score);
+    }
+
+    [Fact]
+    public void CalculateServiceHistoryScore_PoorService_ReturnsLow()
+    {
+        // 1 service / 10 year age = ratio 0.1 => 15, no complete, no authorized
+        var score = CarAnalysisEngine.CalculateServiceHistoryScore(1, 2016, false, false, DateTime.UtcNow.AddMonths(-30));
+        Assert.Equal(5, score); // 15 - 10 (old service)
+    }
+
+    [Fact]
+    public void CalculateServiceHistoryScore_CompleteHistory_AddsBonus()
+    {
+        // 3 services / 5 year age = ratio 0.6 => 50, +10 complete = 60
+        var score = CarAnalysisEngine.CalculateServiceHistoryScore(3, 2021, true, false, DateTime.UtcNow.AddMonths(-12));
+        Assert.Equal(60, score);
+    }
+
+    [Fact]
+    public void CalculateServiceHistoryScore_OldLastService_Penalty()
+    {
+        // 5 services / 5 year age = ratio 1.0 => 90, last service >24 mo => -10 = 80
+        var score = CarAnalysisEngine.CalculateServiceHistoryScore(5, 2021, false, false, DateTime.UtcNow.AddMonths(-30));
+        Assert.Equal(80, score);
+    }
+
+    [Fact]
+    public void CalculateServiceHistoryScore_AllNull_ReturnsFallback()
+    {
+        var score = CarAnalysisEngine.CalculateServiceHistoryScore(null, 2020, null, null, null);
+        Assert.Equal(40, score);
+    }
+
+    // ===== Theft & Security Score =====
+
+    [Theory]
+    [InlineData("Low", 5, true, 100)]   // (100+100)/2 + 5 = 105 => clamped 100
+    [InlineData("High", 1, false, 25)]   // (30+20)/2 = 25
+    [InlineData("Medium", 3, false, 62.5)] // (65+60)/2 = 62.5
+    public void CalculateTheftSecurityScore_Scenarios_ReturnsExpected(string risk, int ncap, bool alarm, decimal expected)
+    {
+        var score = CarAnalysisEngine.CalculateTheftSecurityScore(risk, ncap, alarm);
+        Assert.Equal(expected, score);
+    }
+
+    [Fact]
+    public void CalculateTheftSecurityScore_LowRiskHighNcapWithAlarm_ReturnsCapped100()
+    {
+        var score = CarAnalysisEngine.CalculateTheftSecurityScore("Low", 5, true);
+        Assert.Equal(100, score); // (100+100)/2 + 5 = 105 => clamped to 100
+    }
+
+    [Fact]
+    public void CalculateTheftSecurityScore_AllNull_ReturnsFallback()
+    {
+        var score = CarAnalysisEngine.CalculateTheftSecurityScore(null, null, null);
+        Assert.Equal(60, score);
+    }
+
+    // ===== Drivetrain Score =====
+
+    [Fact]
+    public void CalculateDrivetrainScore_HighReliability_ReturnsHigh()
+    {
+        var score = CarAnalysisEngine.CalculateDrivetrainScore(90, 0, 2000);
+        Assert.Equal(90, score);
+    }
+
+    [Fact]
+    public void CalculateDrivetrainScore_ManyIssues_DeductsPoints()
+    {
+        // 80 - 25 (>=7 issues) = 55
+        var score = CarAnalysisEngine.CalculateDrivetrainScore(80, 8, null);
+        Assert.Equal(55, score);
+    }
+
+    [Fact]
+    public void CalculateDrivetrainScore_HighRepairCost_DeductsPoints()
+    {
+        // 70 - 15 (>15k repair cost) = 55
+        var score = CarAnalysisEngine.CalculateDrivetrainScore(70, null, 20000);
+        Assert.Equal(55, score);
+    }
+
+    [Fact]
+    public void CalculateDrivetrainScore_AllNull_ReturnsFallback()
+    {
+        var score = CarAnalysisEngine.CalculateDrivetrainScore(null, null, null);
+        Assert.Equal(55, score);
+    }
+
+    [Fact]
+    public void CalculateDrivetrainScore_CombinedPenalties_ClampsToZero()
+    {
+        // 20 (reliability) - 25 (>=7 issues) - 15 (>15k repair) = -20 => clamped 0
+        var score = CarAnalysisEngine.CalculateDrivetrainScore(20, 10, 25000);
+        Assert.Equal(0, score);
+    }
+
     // ===== Full Analysis =====
 
     [Fact]
     public void Analyze_ExcellentCar_ReturnsHighScore()
     {
-        var data = new CarDataResult(
-            "ABC123", "Volvo", "XC60", 2024, 10000,
-            "Diesel", 235, "Black",
-            InsuranceIncidents: 0, ManufacturerRecalls: 0,
-            LastInspectionDate: DateTime.UtcNow.AddMonths(-2), InspectionPassed: true,
-            MarketValueSek: 400000m);
+        var data = CreateTestData(2024, 10000, insuranceIncidents: 0, recalls: 0,
+            lastInspection: DateTime.UtcNow.AddMonths(-2), inspectionPassed: true) with
+        {
+            NumberOfOwners = 1, IsCompanyOwned = false,
+            OutstandingDebtSek = 0, TaxDebtSek = 0, HasPurchaseBlock = false,
+            EuroClass = "Euro 6d", Co2EmissionsGPerKm = 100, AnnualTaxSek = 800,
+            AverageMarketPriceSek = 420000, DepreciationRatePercent = 10,
+            ServiceCount = 3, CompleteServiceHistory = true, AuthorizedServiceUsed = true,
+            LastServiceDate = DateTime.UtcNow.AddMonths(-3),
+            TheftRiskCategory = "Low", EuroNcapRating = 5, HasAlarmSystem = true,
+            ReliabilityRating = 90, CommonIssuesCount = 0, AverageRepairCostSek = 2000
+        };
 
         var (score, recommendation, breakdown) = _sut.Analyze(data);
 
@@ -142,12 +435,18 @@ public class CarAnalysisEngineTests
     [Fact]
     public void Analyze_PoorCar_ReturnsLowScore()
     {
-        var data = new CarDataResult(
-            "OLD999", "Saab", "9-3", 2000, 350000,
-            "Petrol", 150, "Gray",
-            InsuranceIncidents: 4, ManufacturerRecalls: 5,
-            LastInspectionDate: DateTime.UtcNow.AddMonths(-30), InspectionPassed: false,
-            MarketValueSek: 15000m);
+        var data = CreateTestData(2000, 350000, insuranceIncidents: 4, recalls: 5,
+            lastInspection: DateTime.UtcNow.AddMonths(-30), inspectionPassed: false) with
+        {
+            NumberOfOwners = 6, IsCompanyOwned = false,
+            OutstandingDebtSek = 250000, TaxDebtSek = 5000, HasPurchaseBlock = false,
+            EuroClass = "Euro 3", Co2EmissionsGPerKm = 220, AnnualTaxSek = 6000,
+            AverageMarketPriceSek = 12000, DepreciationRatePercent = 30,
+            ServiceCount = 1, CompleteServiceHistory = false, AuthorizedServiceUsed = false,
+            LastServiceDate = DateTime.UtcNow.AddMonths(-40),
+            TheftRiskCategory = "High", EuroNcapRating = 1, HasAlarmSystem = false,
+            ReliabilityRating = 20, CommonIssuesCount = 10, AverageRepairCostSek = 25000
+        };
 
         var (score, recommendation, breakdown) = _sut.Analyze(data);
 
@@ -158,12 +457,8 @@ public class CarAnalysisEngineTests
     [Fact]
     public void Analyze_ScoreIsBetween0And100()
     {
-        var data = new CarDataResult(
-            "TEST01", "Test", "Car", 2015, 150000,
-            "Petrol", 100, "White",
-            InsuranceIncidents: 2, ManufacturerRecalls: 1,
-            LastInspectionDate: DateTime.UtcNow.AddMonths(-10), InspectionPassed: true,
-            MarketValueSek: 80000m);
+        var data = CreateTestData(2015, 150000, insuranceIncidents: 2, recalls: 1,
+            lastInspection: DateTime.UtcNow.AddMonths(-10), inspectionPassed: true);
 
         var (score, _, _) = _sut.Analyze(data);
 
@@ -171,14 +466,16 @@ public class CarAnalysisEngineTests
     }
 
     [Fact]
-    public void Analyze_BreakdownContainsAllCategories()
+    public void Analyze_BreakdownContainsAllTwelveCategories()
     {
-        var data = new CarDataResult(
-            "TEST02", "Test", "Car", 2020, 50000,
-            "Electric", 200, "Blue",
-            InsuranceIncidents: 0, ManufacturerRecalls: 0,
-            LastInspectionDate: DateTime.UtcNow.AddMonths(-6), InspectionPassed: true,
-            MarketValueSek: 250000m);
+        var data = CreateTestData(2020, 50000, insuranceIncidents: 0, recalls: 0,
+            lastInspection: DateTime.UtcNow.AddMonths(-6), inspectionPassed: true) with
+        {
+            NumberOfOwners = 2, OutstandingDebtSek = 0, HasPurchaseBlock = false,
+            EuroClass = "Euro 6", ServiceCount = 4, CompleteServiceHistory = true,
+            TheftRiskCategory = "Low", EuroNcapRating = 5,
+            ReliabilityRating = 80, AverageMarketPriceSek = 260000
+        };
 
         var (_, _, breakdown) = _sut.Analyze(data);
 
@@ -187,5 +484,61 @@ public class CarAnalysisEngineTests
         Assert.True(breakdown.InsuranceScore >= 0 && breakdown.InsuranceScore <= 100);
         Assert.True(breakdown.RecallScore >= 0 && breakdown.RecallScore <= 100);
         Assert.True(breakdown.InspectionScore >= 0 && breakdown.InspectionScore <= 100);
+        Assert.True(breakdown.DebtFinanceScore >= 0 && breakdown.DebtFinanceScore <= 100);
+        Assert.True(breakdown.ServiceHistoryScore >= 0 && breakdown.ServiceHistoryScore <= 100);
+        Assert.True(breakdown.DrivetrainScore >= 0 && breakdown.DrivetrainScore <= 100);
+        Assert.True(breakdown.OwnerHistoryScore >= 0 && breakdown.OwnerHistoryScore <= 100);
+        Assert.True(breakdown.MarketValueScore >= 0 && breakdown.MarketValueScore <= 100);
+        Assert.True(breakdown.EnvironmentScore >= 0 && breakdown.EnvironmentScore <= 100);
+        Assert.True(breakdown.TheftSecurityScore >= 0 && breakdown.TheftSecurityScore <= 100);
+    }
+
+    [Fact]
+    public void Analyze_PurchaseBlock_ResultsInVeryLowScore()
+    {
+        var data = CreateTestData(2022, 30000, insuranceIncidents: 0, recalls: 0,
+            lastInspection: DateTime.UtcNow.AddMonths(-2), inspectionPassed: true) with
+        {
+            HasPurchaseBlock = true,
+            NumberOfOwners = 1, OutstandingDebtSek = 0
+        };
+
+        var (_, _, breakdown) = _sut.Analyze(data);
+
+        Assert.Equal(0, breakdown.DebtFinanceScore);
+    }
+
+    [Fact]
+    public void Analyze_WithNullNewFields_UsesFallbackScores()
+    {
+        // Old-style data with no new fields — all new factors should use fallback
+        var data = CreateTestData(2020, 50000, insuranceIncidents: 0, recalls: 0,
+            lastInspection: DateTime.UtcNow.AddMonths(-6), inspectionPassed: true);
+
+        var (score, _, breakdown) = _sut.Analyze(data);
+
+        Assert.Equal(50, breakdown.DebtFinanceScore);
+        Assert.Equal(40, breakdown.ServiceHistoryScore);
+        Assert.Equal(55, breakdown.DrivetrainScore);
+        Assert.Equal(60, breakdown.OwnerHistoryScore);
+        Assert.Equal(50, breakdown.MarketValueScore);
+        Assert.Equal(60, breakdown.EnvironmentScore);
+        Assert.Equal(60, breakdown.TheftSecurityScore);
+        Assert.InRange(score, 0, 100);
+    }
+
+    // Helper to create test CarDataResult with minimal new fields (all null)
+    private static CarDataResult CreateTestData(
+        int year, int mileage,
+        int? insuranceIncidents = null, int? recalls = null,
+        DateTime? lastInspection = null, bool? inspectionPassed = null,
+        decimal? marketValue = 200000m)
+    {
+        return new CarDataResult(
+            "TEST01", "Test", "Car", year, mileage,
+            "Petrol", 100, "White",
+            insuranceIncidents, recalls,
+            lastInspection, inspectionPassed,
+            marketValue);
     }
 }

--- a/tests/CarCheck.Application.Tests/Cars/CarSearchServiceTests.cs
+++ b/tests/CarCheck.Application.Tests/Cars/CarSearchServiceTests.cs
@@ -134,7 +134,7 @@ public class CarSearchServiceTests
         var carId = Guid.NewGuid();
         var cachedAnalysis = new CarAnalysisResponse(
             Guid.NewGuid(), carId, "ABC123", "Volvo", "XC60", 2021,
-            88.5m, "Excellent condition.", new AnalysisBreakdown(90, 85, 100, 100, 100),
+            88.5m, "Excellent condition.", new AnalysisBreakdown(90, 85, 100, 100, 100, 100, 80, 85, 90, 75, 80, 70),
             DateTime.UtcNow);
 
         _cacheService.GetAsync<CarAnalysisResponse>($"analysis:{carId}").Returns(cachedAnalysis);


### PR DESCRIPTION
## Summary
- **7 new analysis factors**: debt & finance (15%), service history (8%), drivetrain reliability (8%), owner history (5%), market value (5%), environment & tax (5%), theft & security (5%)
- **Reweighted all 12 factors** to sum to 1.0 — existing factors adjusted (age 12%, mileage 12%, inspection 10%, insurance 9%, recalls 6%)
- **18 new nullable fields** on `CarDataResult` with backwards-compatible `init` properties
- **Frontend**: grouped 2x2 card layout (vehicle condition, economy & legal, history & maintenance, safety & reliability) + purchase block warning banner
- **52 new tests** (283 total, all passing)

## Changed files (9)
| File | Change |
|------|--------|
| `ICarDataProvider.cs` | 18 new nullable fields on CarDataResult |
| `CarAnalysisEngine.cs` | 7 new scoring methods, reweighted 12 factors |
| `CarDTOs.cs` | AnalysisBreakdown expanded 5→12 fields |
| `CarSearchService.cs` | Updated fallback breakdown constructor |
| `MockCarDataProvider.cs` | Enriched mock data for 5 test cars |
| `CarAnalysisEngineTests.cs` | 52 new unit tests for all scoring methods |
| `CarSearchServiceTests.cs` | Updated AnalysisBreakdown constructor call |
| `car.types.ts` | 7 new fields in AnalysisBreakdown interface |
| `car-analysis-page.tsx` | Grouped 2x2 card layout + purchase block alert |

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 283 tests passing (127+144+11+1)
- [x] `npm run build` — no TS errors
- [ ] Manual test: start backend + frontend, search all 5 mock cars, verify 12-factor breakdown
- [ ] Verify purchase block warning shows for cars with `debtFinanceScore === 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)