### PR TITLE
feat: clickable factor detail views with Sheet drill-down

### DIFF
--- a/frontend/src/features/car/components/factor-detail-content.tsx
+++ b/frontend/src/features/car/components/factor-detail-content.tsx
@@ -1,0 +1,591 @@
+import { Badge } from '@/components/ui/badge'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Progress } from '@/components/ui/progress'
+import { Separator } from '@/components/ui/separator'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { AlertTriangle, CheckCircle2, XCircle, Star } from 'lucide-react'
+import { formatDate, formatSek, formatNumber } from '@/lib/format'
+import { cn } from '@/lib/utils'
+import type { AnalysisDetails, AnalysisBreakdown } from '@/types/car.types'
+
+type FactorKey = keyof AnalysisBreakdown
+
+interface Props {
+  factorKey: FactorKey
+  details: AnalysisDetails
+  year: number
+}
+
+export function FactorDetailContent({ factorKey, details, year }: Props) {
+  switch (factorKey) {
+    case 'inspectionScore':
+      return <InspectionDetail inspections={details.inspections} />
+    case 'serviceHistoryScore':
+      return <ServiceDetail services={details.services} />
+    case 'ownerHistoryScore':
+      return <OwnerDetail owners={details.owners} />
+    case 'insuranceScore':
+      return <InsuranceDetail incidents={details.insuranceIncidents} />
+    case 'recallScore':
+      return <RecallDetail recalls={details.recalls} />
+    case 'debtFinanceScore':
+      return <DebtDetail debts={details.debts} hasPurchaseBlock={details.hasPurchaseBlock} />
+    case 'environmentScore':
+      return (
+        <EnvironmentDetail
+          euroClass={details.euroClass}
+          co2={details.co2EmissionsGPerKm}
+          annualTax={details.annualTaxSek}
+          bonusMalus={details.bonusMalusApplies}
+        />
+      )
+    case 'marketValueScore':
+      return (
+        <MarketDetail
+          marketValue={details.marketValueSek}
+          avgPrice={details.averageMarketPriceSek}
+          depreciation={details.depreciationRatePercent}
+          similarCars={details.similarCars}
+        />
+      )
+    case 'drivetrainScore':
+      return (
+        <DrivetrainDetail
+          reliability={details.reliabilityRating}
+          knownIssues={details.knownIssues}
+          avgRepairCost={details.averageRepairCostSek}
+        />
+      )
+    case 'theftSecurityScore':
+      return (
+        <SecurityDetail
+          theftRisk={details.theftRiskCategory}
+          ncapRating={details.euroNcapRating}
+          hasAlarm={details.hasAlarmSystem}
+          features={details.securityFeatures}
+        />
+      )
+    case 'ageScore':
+      return (
+        <AgeDetail
+          year={year}
+          firstRegistration={details.firstRegistrationDate}
+          isImported={details.isImported}
+        />
+      )
+    case 'mileageScore':
+      return <MileageDetail readings={details.mileageHistory} />
+    default:
+      return <p className="text-sm text-muted-foreground">Ingen detaljdata tillgänglig.</p>
+  }
+}
+
+// ─── Besiktning ───
+
+function InspectionDetail({ inspections }: { inspections: AnalysisDetails['inspections'] }) {
+  if (inspections.length === 0) {
+    return <EmptyState text="Ingen besiktningshistorik tillgänglig." />
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Datum</TableHead>
+          <TableHead>Resultat</TableHead>
+          <TableHead>Anmärkningar</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {inspections.map((i, idx) => (
+          <TableRow key={idx}>
+            <TableCell>{formatDate(i.date)}</TableCell>
+            <TableCell>
+              <Badge variant={i.passed ? 'default' : 'destructive'} className={i.passed ? 'bg-green-100 text-green-700' : ''}>
+                {i.passed ? 'Godkänd' : 'Underkänd'}
+              </Badge>
+            </TableCell>
+            <TableCell className="text-muted-foreground">{i.remarks ?? '–'}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+// ─── Servicehistorik ───
+
+function ServiceDetail({ services }: { services: AnalysisDetails['services'] }) {
+  if (services.length === 0) {
+    return <EmptyState text="Ingen servicehistorik tillgänglig." />
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Datum</TableHead>
+          <TableHead>Verkstad</TableHead>
+          <TableHead>Typ</TableHead>
+          <TableHead className="text-right">Miltal</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {services.map((s, idx) => (
+          <TableRow key={idx}>
+            <TableCell>{formatDate(s.date)}</TableCell>
+            <TableCell>{s.workshop ?? '–'}</TableCell>
+            <TableCell>{s.type}</TableCell>
+            <TableCell className="text-right">
+              {s.mileageAtService != null ? `${formatNumber(s.mileageAtService)} km` : '–'}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+// ─── Ägarhistorik ───
+
+function OwnerDetail({ owners }: { owners: AnalysisDetails['owners'] }) {
+  if (owners.length === 0) {
+    return <EmptyState text="Ingen ägarhistorik tillgänglig." />
+  }
+  return (
+    <div className="space-y-3">
+      {owners.map((o, idx) => (
+        <div key={idx} className="flex items-start gap-3 rounded-lg border p-3">
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-sm font-medium">
+            {idx + 1}
+          </div>
+          <div className="flex-1 space-y-1">
+            <div className="flex items-center gap-2">
+              <Badge variant="outline">{o.isCompany ? 'Företag' : 'Privat'}</Badge>
+              {o.region && <span className="text-sm text-muted-foreground">{o.region}</span>}
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {formatDate(o.from)} — {o.to ? formatDate(o.to) : 'Nuvarande'}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ─── Försäkring ───
+
+function InsuranceDetail({ incidents }: { incidents: AnalysisDetails['insuranceIncidents'] }) {
+  if (incidents.length === 0) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-4">
+        <CheckCircle2 className="h-5 w-5 text-green-600" />
+        <p className="text-sm font-medium text-green-700">Inga försäkringsskador registrerade.</p>
+      </div>
+    )
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Datum</TableHead>
+          <TableHead>Typ</TableHead>
+          <TableHead>Allvarlighet</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {incidents.map((i, idx) => (
+          <TableRow key={idx}>
+            <TableCell>{formatDate(i.date)}</TableCell>
+            <TableCell>{i.type}</TableCell>
+            <TableCell>
+              <Badge variant={i.severity === 'Allvarlig' ? 'destructive' : 'outline'}>
+                {i.severity}
+              </Badge>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+// ─── Återkallelser ───
+
+function RecallDetail({ recalls }: { recalls: AnalysisDetails['recalls'] }) {
+  if (recalls.length === 0) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-4">
+        <CheckCircle2 className="h-5 w-5 text-green-600" />
+        <p className="text-sm font-medium text-green-700">Inga återkallelser registrerade.</p>
+      </div>
+    )
+  }
+  return (
+    <div className="space-y-3">
+      {recalls.map((r, idx) => (
+        <div key={idx} className="flex items-start gap-3 rounded-lg border p-3">
+          {r.resolved ? (
+            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-green-600" />
+          ) : (
+            <XCircle className="mt-0.5 h-5 w-5 shrink-0 text-red-500" />
+          )}
+          <div className="space-y-1">
+            <p className="text-sm">{r.description}</p>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground">{formatDate(r.date)}</span>
+              <Badge variant={r.resolved ? 'default' : 'destructive'} className={r.resolved ? 'bg-green-100 text-green-700' : ''}>
+                {r.resolved ? 'Åtgärdad' : 'Ej åtgärdad'}
+              </Badge>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ─── Skuld & ekonomi ───
+
+function DebtDetail({ debts, hasPurchaseBlock }: { debts: AnalysisDetails['debts']; hasPurchaseBlock: boolean }) {
+  return (
+    <div className="space-y-4">
+      {hasPurchaseBlock && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>
+            Fordonet har en aktiv köpspärr hos Kronofogden.
+          </AlertDescription>
+        </Alert>
+      )}
+      {debts.length === 0 ? (
+        !hasPurchaseBlock && (
+          <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-4">
+            <CheckCircle2 className="h-5 w-5 text-green-600" />
+            <p className="text-sm font-medium text-green-700">Inga skulder registrerade.</p>
+          </div>
+        )
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Typ</TableHead>
+              <TableHead className="text-right">Belopp</TableHead>
+              <TableHead>Datum</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {debts.map((d, idx) => (
+              <TableRow key={idx}>
+                <TableCell>{d.type}</TableCell>
+                <TableCell className="text-right">{formatSek(d.amountSek)}</TableCell>
+                <TableCell>{formatDate(d.date)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  )
+}
+
+// ─── Miljö & skatt ───
+
+function EnvironmentDetail({
+  euroClass,
+  co2,
+  annualTax,
+  bonusMalus,
+}: {
+  euroClass: string | null
+  co2: number | null
+  annualTax: number | null
+  bonusMalus: boolean | null
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <KeyValue label="Euroklass" value={euroClass ?? '–'} />
+      <KeyValue label="CO₂-utsläpp" value={co2 != null ? `${co2} g/km` : '–'} />
+      <KeyValue label="Årlig fordonsskatt" value={annualTax != null ? formatSek(annualTax) : '–'} />
+      <KeyValue label="Bonus/Malus" value={bonusMalus == null ? '–' : bonusMalus ? 'Ja' : 'Nej'} />
+    </div>
+  )
+}
+
+// ─── Marknadsvärde ───
+
+function MarketDetail({
+  marketValue,
+  avgPrice,
+  depreciation,
+  similarCars,
+}: {
+  marketValue: number | null
+  avgPrice: number | null
+  depreciation: number | null
+  similarCars: AnalysisDetails['similarCars']
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <KeyValue label="Uppskattat marknadsvärde" value={marketValue != null ? formatSek(marketValue) : '–'} />
+        <KeyValue label="Genomsnittspris" value={avgPrice != null ? formatSek(avgPrice) : '–'} />
+        <KeyValue
+          label="Värdeminskning"
+          value={depreciation != null ? `${depreciation.toFixed(1)}%` : '–'}
+        />
+      </div>
+
+      {similarCars.length > 0 && (
+        <>
+          <Separator />
+          <h4 className="text-sm font-medium">Liknande bilar på marknaden</h4>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Modell</TableHead>
+                <TableHead>Årsmodell</TableHead>
+                <TableHead className="text-right">Pris</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {similarCars.map((c, idx) => (
+                <TableRow key={idx}>
+                  <TableCell>{c.model}</TableCell>
+                  <TableCell>{c.year}</TableCell>
+                  <TableCell className="text-right">{formatSek(c.priceSek)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </>
+      )}
+    </div>
+  )
+}
+
+// ─── Drivlina & tillförlitlighet ───
+
+function DrivetrainDetail({
+  reliability,
+  knownIssues,
+  avgRepairCost,
+}: {
+  reliability: number | null
+  knownIssues: string[]
+  avgRepairCost: number | null
+}) {
+  return (
+    <div className="space-y-4">
+      {reliability != null && (
+        <div className="space-y-1">
+          <div className="flex items-center justify-between text-sm">
+            <span className="font-medium">Tillförlitlighet</span>
+            <span>{reliability.toFixed(1)} / 10</span>
+          </div>
+          <Progress value={reliability * 10} className="h-2" />
+        </div>
+      )}
+
+      <KeyValue label="Genomsnittlig reparationskostnad" value={avgRepairCost != null ? formatSek(avgRepairCost) : '–'} />
+
+      {knownIssues.length > 0 && (
+        <>
+          <Separator />
+          <h4 className="text-sm font-medium">Kända problem</h4>
+          <ul className="space-y-1">
+            {knownIssues.map((issue, idx) => (
+              <li key={idx} className="flex items-start gap-2 text-sm text-muted-foreground">
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-yellow-500" />
+                {issue}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  )
+}
+
+// ─── Stöld & säkerhet ───
+
+function SecurityDetail({
+  theftRisk,
+  ncapRating,
+  hasAlarm,
+  features,
+}: {
+  theftRisk: string | null
+  ncapRating: number | null
+  hasAlarm: boolean | null
+  features: string[]
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <KeyValue
+          label="Stöldrisk"
+          value={
+            theftRisk ? (
+              <Badge
+                variant="outline"
+                className={cn(
+                  theftRisk === 'Låg' && 'border-green-300 text-green-700',
+                  theftRisk === 'Medel' && 'border-yellow-300 text-yellow-700',
+                  theftRisk === 'Hög' && 'border-red-300 text-red-700'
+                )}
+              >
+                {theftRisk}
+              </Badge>
+            ) : (
+              '–'
+            )
+          }
+        />
+        <KeyValue
+          label="Euro NCAP"
+          value={
+            ncapRating != null ? (
+              <span className="flex items-center gap-0.5">
+                {Array.from({ length: 5 }, (_, i) => (
+                  <Star
+                    key={i}
+                    className={cn(
+                      'h-4 w-4',
+                      i < ncapRating ? 'fill-yellow-400 text-yellow-400' : 'text-muted-foreground/30'
+                    )}
+                  />
+                ))}
+              </span>
+            ) : (
+              '–'
+            )
+          }
+        />
+        <KeyValue
+          label="Larmsystem"
+          value={hasAlarm == null ? '–' : hasAlarm ? 'Ja' : 'Nej'}
+        />
+      </div>
+
+      {features.length > 0 && (
+        <>
+          <Separator />
+          <h4 className="text-sm font-medium">Säkerhetsutrustning</h4>
+          <div className="flex flex-wrap gap-2">
+            {features.map((f, idx) => (
+              <Badge key={idx} variant="secondary">
+                {f}
+              </Badge>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+// ─── Ålder ───
+
+function AgeDetail({
+  year,
+  firstRegistration,
+  isImported,
+}: {
+  year: number
+  firstRegistration: string | null
+  isImported: boolean | null
+}) {
+  const currentYear = new Date().getFullYear()
+  const age = currentYear - year
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <KeyValue label="Årsmodell" value={String(year)} />
+      <KeyValue label="Ålder" value={`${age} år`} />
+      <KeyValue
+        label="Första registrering"
+        value={firstRegistration ? formatDate(firstRegistration) : '–'}
+      />
+      <KeyValue
+        label="Importerad"
+        value={isImported == null ? '–' : isImported ? 'Ja' : 'Nej'}
+      />
+    </div>
+  )
+}
+
+// ─── Miltal ───
+
+function MileageDetail({ readings }: { readings: AnalysisDetails['mileageHistory'] }) {
+  if (readings.length === 0) {
+    return <EmptyState text="Ingen miltalshistorik tillgänglig." />
+  }
+
+  // Sort by date ascending
+  const sorted = [...readings].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+
+  return (
+    <div className="space-y-3">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Datum</TableHead>
+            <TableHead className="text-right">Miltal</TableHead>
+            <TableHead>Källa</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sorted.map((r, idx) => {
+            const prevMileage = idx > 0 ? sorted[idx - 1].mileage : null
+            const isSuspicious = prevMileage !== null && r.mileage < prevMileage
+            return (
+              <TableRow
+                key={idx}
+                className={cn(isSuspicious && 'bg-red-50')}
+              >
+                <TableCell>{formatDate(r.date)}</TableCell>
+                <TableCell className={cn('text-right', isSuspicious && 'font-bold text-red-600')}>
+                  {formatNumber(r.mileage)} km
+                  {isSuspicious && (
+                    <AlertTriangle className="ml-1 inline h-3.5 w-3.5 text-red-500" />
+                  )}
+                </TableCell>
+                <TableCell>{r.source}</TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+      {sorted.some((r, idx) => idx > 0 && r.mileage < sorted[idx - 1].mileage) && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>
+            Miltalet har minskat mellan avläsningar — detta kan tyda på manipulation.
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  )
+}
+
+// ─── Helpers ───
+
+function EmptyState({ text }: { text: string }) {
+  return <p className="py-4 text-center text-sm text-muted-foreground">{text}</p>
+}
+
+function KeyValue({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <div className="text-sm font-medium">{value}</div>
+    </div>
+  )
+}

--- a/frontend/src/features/car/components/factor-detail-sheet.tsx
+++ b/frontend/src/features/car/components/factor-detail-sheet.tsx
@@ -1,0 +1,58 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet'
+import { Progress } from '@/components/ui/progress'
+import { getScoreColor } from '@/lib/format'
+import { cn } from '@/lib/utils'
+import { FactorDetailContent } from './factor-detail-content'
+import type { AnalysisBreakdown, AnalysisDetails } from '@/types/car.types'
+
+type FactorKey = keyof AnalysisBreakdown
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  factorKey: FactorKey | null
+  factorLabel: string
+  score: number
+  details: AnalysisDetails | null
+  year: number
+}
+
+export function FactorDetailSheet({
+  open,
+  onOpenChange,
+  factorKey,
+  factorLabel,
+  score,
+  details,
+  year,
+}: Props) {
+  const rounded = Math.round(score)
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle>{factorLabel}</SheetTitle>
+          <SheetDescription>
+            <span className={cn('text-lg font-bold', getScoreColor(rounded))}>{rounded}</span>
+            <span className="text-muted-foreground"> / 100</span>
+          </SheetDescription>
+          <Progress value={rounded} className="h-2" />
+        </SheetHeader>
+        <div className="mt-6">
+          {factorKey && details ? (
+            <FactorDetailContent factorKey={factorKey} details={details} year={year} />
+          ) : (
+            <p className="text-sm text-muted-foreground">Ingen detaljdata tillgänglig.</p>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/frontend/src/types/car.types.ts
+++ b/frontend/src/types/car.types.ts
@@ -27,6 +27,7 @@ export interface CarAnalysisResponse {
   recommendation: string
   breakdown: AnalysisBreakdown
   createdAt: string
+  details: AnalysisDetails | null
 }
 
 export interface AnalysisBreakdown {
@@ -42,4 +43,84 @@ export interface AnalysisBreakdown {
   marketValueScore: number
   environmentScore: number
   theftSecurityScore: number
+}
+
+// Detail record types for factor drill-down
+
+export interface InspectionRecord {
+  date: string
+  passed: boolean
+  remarks: string | null
+}
+
+export interface ServiceRecord {
+  date: string
+  workshop: string | null
+  type: string
+  mileageAtService: number | null
+}
+
+export interface OwnerRecord {
+  from: string
+  to: string | null
+  isCompany: boolean
+  region: string | null
+}
+
+export interface InsuranceIncidentRecord {
+  date: string
+  type: string
+  severity: string
+}
+
+export interface RecallRecord {
+  date: string
+  description: string
+  resolved: boolean
+}
+
+export interface DebtRecord {
+  type: string
+  amountSek: number
+  date: string
+}
+
+export interface MileageReadingRecord {
+  date: string
+  mileage: number
+  source: string
+}
+
+export interface MarketComparisonRecord {
+  model: string
+  year: number
+  priceSek: number
+}
+
+export interface AnalysisDetails {
+  inspections: InspectionRecord[]
+  services: ServiceRecord[]
+  owners: OwnerRecord[]
+  insuranceIncidents: InsuranceIncidentRecord[]
+  recalls: RecallRecord[]
+  debts: DebtRecord[]
+  hasPurchaseBlock: boolean
+  euroClass: string | null
+  co2EmissionsGPerKm: number | null
+  annualTaxSek: number | null
+  bonusMalusApplies: boolean | null
+  marketValueSek: number | null
+  averageMarketPriceSek: number | null
+  depreciationRatePercent: number | null
+  similarCars: MarketComparisonRecord[]
+  reliabilityRating: number | null
+  knownIssues: string[]
+  averageRepairCostSek: number | null
+  theftRiskCategory: string | null
+  euroNcapRating: number | null
+  hasAlarmSystem: boolean | null
+  securityFeatures: string[]
+  firstRegistrationDate: string | null
+  isImported: boolean | null
+  mileageHistory: MileageReadingRecord[]
 }

--- a/src/CarCheck.Application/Cars/CarSearchService.cs
+++ b/src/CarCheck.Application/Cars/CarSearchService.cs
@@ -129,6 +129,9 @@ public class CarSearchService
         // Run analysis
         var (score, recommendation, breakdown) = _analysisEngine.Analyze(externalData);
 
+        // Build detail data for drill-down views
+        var details = MapToAnalysisDetails(externalData);
+
         // Persist result
         var analysisResult = AnalysisResult.Create(carId, score, recommendation);
         await _analysisResultRepository.AddAsync(analysisResult, cancellationToken);
@@ -143,7 +146,8 @@ public class CarSearchService
             score,
             recommendation,
             breakdown,
-            analysisResult.CreatedAt);
+            analysisResult.CreatedAt,
+            details);
 
         await _cacheService.SetAsync(analysisCacheKey, analysisResponse, CacheDuration, cancellationToken);
 
@@ -185,5 +189,35 @@ public class CarSearchService
             analysis.Recommendation,
             breakdown ?? new AnalysisBreakdown(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
             analysis.CreatedAt);
+    }
+
+    private static AnalysisDetails MapToAnalysisDetails(CarDataResult data)
+    {
+        return new AnalysisDetails(
+            Inspections: data.Inspections ?? [],
+            Services: data.ServiceRecords ?? [],
+            Owners: data.OwnerRecords ?? [],
+            InsuranceIncidents: data.InsuranceIncidentRecords ?? [],
+            Recalls: data.RecallRecords ?? [],
+            Debts: data.DebtRecords ?? [],
+            HasPurchaseBlock: data.HasPurchaseBlock ?? false,
+            EuroClass: data.EuroClass,
+            Co2EmissionsGPerKm: data.Co2EmissionsGPerKm,
+            AnnualTaxSek: data.AnnualTaxSek,
+            BonusMalusApplies: data.BonusMalusApplies,
+            MarketValueSek: data.MarketValueSek,
+            AverageMarketPriceSek: data.AverageMarketPriceSek,
+            DepreciationRatePercent: data.DepreciationRatePercent,
+            SimilarCars: data.SimilarCars ?? [],
+            ReliabilityRating: data.ReliabilityRating,
+            KnownIssues: data.KnownIssues ?? [],
+            AverageRepairCostSek: data.AverageRepairCostSek,
+            TheftRiskCategory: data.TheftRiskCategory,
+            EuroNcapRating: data.EuroNcapRating,
+            HasAlarmSystem: data.HasAlarmSystem,
+            SecurityFeatures: data.SecurityFeatures ?? [],
+            FirstRegistrationDate: data.FirstRegistrationDate,
+            IsImported: data.IsImported,
+            MileageHistory: data.MileageReadings ?? []);
     }
 }

--- a/src/CarCheck.Application/Cars/DTOs/CarDTOs.cs
+++ b/src/CarCheck.Application/Cars/DTOs/CarDTOs.cs
@@ -24,7 +24,8 @@ public record CarAnalysisResponse(
     decimal Score,
     string Recommendation,
     AnalysisBreakdown Breakdown,
-    DateTime CreatedAt);
+    DateTime CreatedAt,
+    AnalysisDetails? Details = null);
 
 public record AnalysisBreakdown(
     decimal AgeScore,
@@ -39,3 +40,40 @@ public record AnalysisBreakdown(
     decimal MarketValueScore,
     decimal EnvironmentScore,
     decimal TheftSecurityScore);
+
+// Detail record types for factor drill-down views
+public record InspectionRecord(DateTime Date, bool Passed, string? Remarks);
+public record ServiceRecord(DateTime Date, string? Workshop, string Type, int? MileageAtService);
+public record OwnerRecord(DateTime From, DateTime? To, bool IsCompany, string? Region);
+public record InsuranceIncidentRecord(DateTime Date, string Type, string Severity);
+public record RecallRecord(DateTime Date, string Description, bool Resolved);
+public record DebtRecord(string Type, decimal AmountSek, DateTime Date);
+public record MileageReadingRecord(DateTime Date, int Mileage, string Source);
+public record MarketComparisonRecord(string Model, int Year, decimal PriceSek);
+
+public record AnalysisDetails(
+    List<InspectionRecord> Inspections,
+    List<ServiceRecord> Services,
+    List<OwnerRecord> Owners,
+    List<InsuranceIncidentRecord> InsuranceIncidents,
+    List<RecallRecord> Recalls,
+    List<DebtRecord> Debts,
+    bool HasPurchaseBlock,
+    string? EuroClass,
+    int? Co2EmissionsGPerKm,
+    decimal? AnnualTaxSek,
+    bool? BonusMalusApplies,
+    decimal? MarketValueSek,
+    decimal? AverageMarketPriceSek,
+    decimal? DepreciationRatePercent,
+    List<MarketComparisonRecord> SimilarCars,
+    decimal? ReliabilityRating,
+    List<string> KnownIssues,
+    decimal? AverageRepairCostSek,
+    string? TheftRiskCategory,
+    int? EuroNcapRating,
+    bool? HasAlarmSystem,
+    List<string> SecurityFeatures,
+    DateTime? FirstRegistrationDate,
+    bool? IsImported,
+    List<MileageReadingRecord> MileageHistory);

--- a/src/CarCheck.Application/Interfaces/ICarDataProvider.cs
+++ b/src/CarCheck.Application/Interfaces/ICarDataProvider.cs
@@ -1,3 +1,5 @@
+using CarCheck.Application.Cars.DTOs;
+
 namespace CarCheck.Application.Interfaces;
 
 public interface ICarDataProvider
@@ -55,4 +57,17 @@ public record CarDataResult(
     public decimal? ReliabilityRating { get; init; }
     public int? CommonIssuesCount { get; init; }
     public decimal? AverageRepairCostSek { get; init; }
+
+    // Detail lists for factor drill-down
+    public List<InspectionRecord>? Inspections { get; init; }
+    public List<ServiceRecord>? ServiceRecords { get; init; }
+    public List<OwnerRecord>? OwnerRecords { get; init; }
+    public List<InsuranceIncidentRecord>? InsuranceIncidentRecords { get; init; }
+    public List<RecallRecord>? RecallRecords { get; init; }
+    public List<DebtRecord>? DebtRecords { get; init; }
+    public List<MileageReadingRecord>? MileageReadings { get; init; }
+    public List<MarketComparisonRecord>? SimilarCars { get; init; }
+    public List<string>? KnownIssues { get; init; }
+    public List<string>? SecurityFeatures { get; init; }
+    public bool? IsImported { get; init; }
 }

--- a/src/CarCheck.Infrastructure/External/MockCarDataProvider.cs
+++ b/src/CarCheck.Infrastructure/External/MockCarDataProvider.cs
@@ -1,3 +1,4 @@
+using CarCheck.Application.Cars.DTOs;
 using CarCheck.Application.Interfaces;
 
 namespace CarCheck.Infrastructure.External;
@@ -25,7 +26,51 @@ public class MockCarDataProvider : ICarDataProvider
             ServiceCount = 5, AuthorizedServiceUsed = true,
             LastServiceDate = DateTime.UtcNow.AddMonths(-4), CompleteServiceHistory = true,
             TheftRiskCategory = "Low", EuroNcapRating = 5, HasAlarmSystem = true,
-            ReliabilityRating = 85m, CommonIssuesCount = 1, AverageRepairCostSek = 4500m
+            ReliabilityRating = 85m, CommonIssuesCount = 1, AverageRepairCostSek = 4500m,
+
+            Inspections = new List<InspectionRecord>
+            {
+                new(new DateTime(2022, 3, 10, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2023, 3, 22, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2025, 3, 5, 0, 0, 0, DateTimeKind.Utc), true, null),
+            },
+            ServiceRecords = new List<ServiceRecord>
+            {
+                new(new DateTime(2021, 9, 15, 0, 0, 0, DateTimeKind.Utc), "Volvo Servicecenter Stockholm", "Liten service", 8700),
+                new(new DateTime(2022, 3, 8, 0, 0, 0, DateTimeKind.Utc), "Volvo Servicecenter Stockholm", "Stor service", 17500),
+                new(new DateTime(2023, 3, 20, 0, 0, 0, DateTimeKind.Utc), "Volvo Servicecenter Stockholm", "Liten service", 26200),
+                new(new DateTime(2024, 4, 2, 0, 0, 0, DateTimeKind.Utc), "Volvo Servicecenter Stockholm", "Stor service", 30500),
+                new(new DateTime(2025, 10, 14, 0, 0, 0, DateTimeKind.Utc), "Volvo Servicecenter Stockholm", "Liten service", 35000),
+            },
+            OwnerRecords = new List<OwnerRecord>
+            {
+                new(new DateTime(2021, 3, 15, 0, 0, 0, DateTimeKind.Utc), null, false, "Stockholm"),
+            },
+            InsuranceIncidentRecords = new List<InsuranceIncidentRecord>(),
+            RecallRecords = new List<RecallRecord>(),
+            DebtRecords = new List<DebtRecord>(),
+            MileageReadings = new List<MileageReadingRecord>
+            {
+                new(new DateTime(2022, 3, 10, 0, 0, 0, DateTimeKind.Utc), 8750, "Besiktning"),
+                new(new DateTime(2023, 3, 22, 0, 0, 0, DateTimeKind.Utc), 17500, "Besiktning"),
+                new(new DateTime(2024, 4, 2, 0, 0, 0, DateTimeKind.Utc), 26250, "Service"),
+                new(new DateTime(2025, 3, 5, 0, 0, 0, DateTimeKind.Utc), 35000, "Besiktning"),
+            },
+            SimilarCars = new List<MarketComparisonRecord>
+            {
+                new("XC60", 2020, 340000m),
+                new("XC60", 2021, 390000m),
+                new("XC60", 2022, 445000m),
+            },
+            KnownIssues = new List<string>
+            {
+                "Sporadisk varning för startmotor vid kall väderlek",
+            },
+            SecurityFeatures = new List<string>
+            {
+                "Volvo On Call", "Startspärr", "Larm", "GPS-spårning",
+            },
+            IsImported = false,
         },
 
         ["DEF456"] = new CarDataResult(
@@ -43,7 +88,69 @@ public class MockCarDataProvider : ICarDataProvider
             ServiceCount = 6, AuthorizedServiceUsed = true,
             LastServiceDate = DateTime.UtcNow.AddMonths(-6), CompleteServiceHistory = true,
             TheftRiskCategory = "Medium", EuroNcapRating = 5, HasAlarmSystem = true,
-            ReliabilityRating = 72m, CommonIssuesCount = 3, AverageRepairCostSek = 8500m
+            ReliabilityRating = 72m, CommonIssuesCount = 3, AverageRepairCostSek = 8500m,
+
+            Inspections = new List<InspectionRecord>
+            {
+                new(new DateTime(2019, 6, 12, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2020, 6, 18, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2021, 6, 25, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2022, 7, 3, 0, 0, 0, DateTimeKind.Utc), true, "Slitage bromsskivor fram"),
+                new(new DateTime(2025, 6, 10, 0, 0, 0, DateTimeKind.Utc), true, null),
+            },
+            ServiceRecords = new List<ServiceRecord>
+            {
+                new(new DateTime(2019, 3, 5, 0, 0, 0, DateTimeKind.Utc), "BMW Motorrad Stockholm", "Liten service", 12500),
+                new(new DateTime(2020, 3, 18, 0, 0, 0, DateTimeKind.Utc), "BMW Motorrad Stockholm", "Stor service", 25000),
+                new(new DateTime(2021, 4, 10, 0, 0, 0, DateTimeKind.Utc), "BMW Motorrad Stockholm", "Liten service", 37500),
+                new(new DateTime(2022, 5, 22, 0, 0, 0, DateTimeKind.Utc), "Mekonomen Solna", "Stor service", 50000),
+                new(new DateTime(2023, 6, 14, 0, 0, 0, DateTimeKind.Utc), "Mekonomen Solna", "Liten service", 62500),
+                new(new DateTime(2025, 8, 2, 0, 0, 0, DateTimeKind.Utc), "BMW Motorrad Stockholm", "Stor service", 87000),
+            },
+            OwnerRecords = new List<OwnerRecord>
+            {
+                new(new DateTime(2018, 6, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2021, 9, 15, 0, 0, 0, DateTimeKind.Utc), false, "Göteborg"),
+                new(new DateTime(2021, 9, 15, 0, 0, 0, DateTimeKind.Utc), null, false, "Stockholm"),
+            },
+            InsuranceIncidentRecords = new List<InsuranceIncidentRecord>
+            {
+                new(new DateTime(2022, 11, 8, 0, 0, 0, DateTimeKind.Utc), "Parkeringsskada", "Mindre"),
+            },
+            RecallRecords = new List<RecallRecord>
+            {
+                new(new DateTime(2020, 2, 14, 0, 0, 0, DateTimeKind.Utc), "Uppdatering av motorstyrningsprogramvara", true),
+            },
+            DebtRecords = new List<DebtRecord>
+            {
+                new("Billån", 45000m, new DateTime(2021, 9, 15, 0, 0, 0, DateTimeKind.Utc)),
+            },
+            MileageReadings = new List<MileageReadingRecord>
+            {
+                new(new DateTime(2019, 6, 12, 0, 0, 0, DateTimeKind.Utc), 12500, "Besiktning"),
+                new(new DateTime(2020, 3, 18, 0, 0, 0, DateTimeKind.Utc), 25000, "Service"),
+                new(new DateTime(2020, 6, 18, 0, 0, 0, DateTimeKind.Utc), 27500, "Besiktning"),
+                new(new DateTime(2021, 6, 25, 0, 0, 0, DateTimeKind.Utc), 37500, "Besiktning"),
+                new(new DateTime(2022, 7, 3, 0, 0, 0, DateTimeKind.Utc), 50000, "Besiktning"),
+                new(new DateTime(2023, 6, 14, 0, 0, 0, DateTimeKind.Utc), 62500, "Service"),
+                new(new DateTime(2025, 6, 10, 0, 0, 0, DateTimeKind.Utc), 87000, "Besiktning"),
+            },
+            SimilarCars = new List<MarketComparisonRecord>
+            {
+                new("320d", 2017, 175000m),
+                new("320d", 2018, 220000m),
+                new("320d", 2019, 265000m),
+            },
+            KnownIssues = new List<string>
+            {
+                "EGR-ventil kan behöva bytas vid 120 000 km",
+                "Kedjesträckare kontrolleras vid 100 000 km",
+                "Oljeläckage vid oljefilterhus",
+            },
+            SecurityFeatures = new List<string>
+            {
+                "BMW Connected Drive", "Startspärr", "Larm",
+            },
+            IsImported = false,
         },
 
         ["GHI789"] = new CarDataResult(
@@ -61,7 +168,68 @@ public class MockCarDataProvider : ICarDataProvider
             ServiceCount = 7, AuthorizedServiceUsed = false,
             LastServiceDate = DateTime.UtcNow.AddMonths(-18), CompleteServiceHistory = false,
             TheftRiskCategory = "Low", EuroNcapRating = 4, HasAlarmSystem = false,
-            ReliabilityRating = 90m, CommonIssuesCount = 1, AverageRepairCostSek = 2500m
+            ReliabilityRating = 90m, CommonIssuesCount = 1, AverageRepairCostSek = 2500m,
+
+            Inspections = new List<InspectionRecord>
+            {
+                new(new DateTime(2016, 1, 25, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2017, 2, 8, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2018, 1, 30, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2019, 2, 14, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2021, 3, 3, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2023, 2, 20, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc), false, "Bromsskivor slitna, handbroms ur funktion"),
+            },
+            ServiceRecords = new List<ServiceRecord>
+            {
+                new(new DateTime(2016, 1, 20, 0, 0, 0, DateTimeKind.Utc), "Mekonomen Järfälla", "Liten service", 13000),
+                new(new DateTime(2017, 3, 10, 0, 0, 0, DateTimeKind.Utc), "Mekonomen Järfälla", "Liten service", 26000),
+                new(new DateTime(2018, 4, 5, 0, 0, 0, DateTimeKind.Utc), "Mekonomen Järfälla", "Stor service", 39000),
+                new(new DateTime(2019, 5, 15, 0, 0, 0, DateTimeKind.Utc), "OK Q8 Bilverkstad", "Liten service", 52000),
+                new(new DateTime(2020, 6, 22, 0, 0, 0, DateTimeKind.Utc), "OK Q8 Bilverkstad", "Liten service", 65000),
+                new(new DateTime(2021, 8, 10, 0, 0, 0, DateTimeKind.Utc), "Mekonomen Järfälla", "Liten service", 78000),
+                new(new DateTime(2023, 2, 18, 0, 0, 0, DateTimeKind.Utc), "OK Q8 Bilverkstad", "Liten service", 117000),
+            },
+            OwnerRecords = new List<OwnerRecord>
+            {
+                new(new DateTime(2015, 1, 20, 0, 0, 0, DateTimeKind.Utc), new DateTime(2018, 5, 10, 0, 0, 0, DateTimeKind.Utc), false, "Uppsala"),
+                new(new DateTime(2018, 5, 10, 0, 0, 0, DateTimeKind.Utc), new DateTime(2022, 8, 1, 0, 0, 0, DateTimeKind.Utc), false, "Västerås"),
+                new(new DateTime(2022, 8, 1, 0, 0, 0, DateTimeKind.Utc), null, false, "Stockholm"),
+            },
+            InsuranceIncidentRecords = new List<InsuranceIncidentRecord>
+            {
+                new(new DateTime(2019, 8, 22, 0, 0, 0, DateTimeKind.Utc), "Kollision", "Mindre"),
+                new(new DateTime(2021, 4, 3, 0, 0, 0, DateTimeKind.Utc), "Stenskott vindruta", "Mindre"),
+            },
+            RecallRecords = new List<RecallRecord>(),
+            DebtRecords = new List<DebtRecord>(),
+            MileageReadings = new List<MileageReadingRecord>
+            {
+                new(new DateTime(2016, 1, 25, 0, 0, 0, DateTimeKind.Utc), 13000, "Besiktning"),
+                new(new DateTime(2017, 2, 8, 0, 0, 0, DateTimeKind.Utc), 26000, "Besiktning"),
+                new(new DateTime(2018, 1, 30, 0, 0, 0, DateTimeKind.Utc), 39000, "Besiktning"),
+                new(new DateTime(2019, 2, 14, 0, 0, 0, DateTimeKind.Utc), 52000, "Besiktning"),
+                new(new DateTime(2020, 6, 22, 0, 0, 0, DateTimeKind.Utc), 65000, "Service"),
+                new(new DateTime(2021, 3, 3, 0, 0, 0, DateTimeKind.Utc), 78000, "Besiktning"),
+                new(new DateTime(2022, 8, 1, 0, 0, 0, DateTimeKind.Utc), 91000, "Ägarebyte"),
+                new(new DateTime(2023, 2, 20, 0, 0, 0, DateTimeKind.Utc), 117000, "Besiktning"),
+                new(new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc), 142000, "Besiktning"),
+            },
+            SimilarCars = new List<MarketComparisonRecord>
+            {
+                new("Corolla", 2014, 75000m),
+                new("Corolla", 2015, 98000m),
+                new("Corolla", 2016, 120000m),
+            },
+            KnownIssues = new List<string>
+            {
+                "Vattenpump kan börja läcka vid 150 000 km",
+            },
+            SecurityFeatures = new List<string>
+            {
+                "Startspärr",
+            },
+            IsImported = false,
         },
 
         ["JKL012"] = new CarDataResult(
@@ -79,7 +247,54 @@ public class MockCarDataProvider : ICarDataProvider
             ServiceCount = 3, AuthorizedServiceUsed = true,
             LastServiceDate = DateTime.UtcNow.AddMonths(-2), CompleteServiceHistory = true,
             TheftRiskCategory = "Medium", EuroNcapRating = 5, HasAlarmSystem = true,
-            ReliabilityRating = 75m, CommonIssuesCount = 2, AverageRepairCostSek = 12000m
+            ReliabilityRating = 75m, CommonIssuesCount = 2, AverageRepairCostSek = 12000m,
+
+            Inspections = new List<InspectionRecord>
+            {
+                new(new DateTime(2024, 9, 18, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2025, 9, 5, 0, 0, 0, DateTimeKind.Utc), true, null),
+            },
+            ServiceRecords = new List<ServiceRecord>
+            {
+                new(new DateTime(2024, 3, 12, 0, 0, 0, DateTimeKind.Utc), "Tesla Service Center Kungens Kurva", "Underhållsservice", 4000),
+                new(new DateTime(2024, 9, 15, 0, 0, 0, DateTimeKind.Utc), "Tesla Service Center Kungens Kurva", "Underhållsservice", 8000),
+                new(new DateTime(2025, 12, 3, 0, 0, 0, DateTimeKind.Utc), "Tesla Service Center Kungens Kurva", "Underhållsservice", 12000),
+            },
+            OwnerRecords = new List<OwnerRecord>
+            {
+                new(new DateTime(2023, 9, 10, 0, 0, 0, DateTimeKind.Utc), null, true, "Stockholm"),
+            },
+            InsuranceIncidentRecords = new List<InsuranceIncidentRecord>(),
+            RecallRecords = new List<RecallRecord>
+            {
+                new(new DateTime(2024, 1, 20, 0, 0, 0, DateTimeKind.Utc), "Uppdatering av autopilot-programvara", true),
+                new(new DateTime(2025, 6, 5, 0, 0, 0, DateTimeKind.Utc), "Kontroll av bromssystem", false),
+            },
+            DebtRecords = new List<DebtRecord>
+            {
+                new("Leasingavtal", 120000m, new DateTime(2023, 9, 10, 0, 0, 0, DateTimeKind.Utc)),
+            },
+            MileageReadings = new List<MileageReadingRecord>
+            {
+                new(new DateTime(2024, 9, 18, 0, 0, 0, DateTimeKind.Utc), 6000, "Besiktning"),
+                new(new DateTime(2025, 9, 5, 0, 0, 0, DateTimeKind.Utc), 12000, "Besiktning"),
+            },
+            SimilarCars = new List<MarketComparisonRecord>
+            {
+                new("Model 3", 2022, 370000m),
+                new("Model 3", 2023, 425000m),
+                new("Model Y", 2023, 460000m),
+            },
+            KnownIssues = new List<string>
+            {
+                "Sprickor i plastpaneler vid låga temperaturer",
+                "Fantombromsning vid adaptiv farthållare",
+            },
+            SecurityFeatures = new List<string>
+            {
+                "Tesla Sentry Mode", "GPS-spårning", "Startspärr", "Mobilapp-lås",
+            },
+            IsImported = true,
         },
 
         ["MNO345"] = new CarDataResult(
@@ -97,7 +312,85 @@ public class MockCarDataProvider : ICarDataProvider
             ServiceCount = 4, AuthorizedServiceUsed = false,
             LastServiceDate = DateTime.UtcNow.AddMonths(-30), CompleteServiceHistory = false,
             TheftRiskCategory = "High", EuroNcapRating = 3, HasAlarmSystem = false,
-            ReliabilityRating = 55m, CommonIssuesCount = 6, AverageRepairCostSek = 9000m
+            ReliabilityRating = 55m, CommonIssuesCount = 6, AverageRepairCostSek = 9000m,
+
+            Inspections = new List<InspectionRecord>
+            {
+                new(new DateTime(2011, 4, 18, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2012, 4, 22, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2013, 5, 6, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2014, 5, 12, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2015, 5, 20, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2017, 6, 1, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2019, 6, 15, 0, 0, 0, DateTimeKind.Utc), false, "Rostskador på bärande balkar"),
+                new(new DateTime(2021, 7, 2, 0, 0, 0, DateTimeKind.Utc), true, null),
+                new(new DateTime(2023, 7, 18, 0, 0, 0, DateTimeKind.Utc), false, "Avgassystem läcker, stötdämpare slitna"),
+                new(new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc), false, "Bromsskivor under gräns, oljeläckage"),
+            },
+            ServiceRecords = new List<ServiceRecord>
+            {
+                new(new DateTime(2012, 5, 10, 0, 0, 0, DateTimeKind.Utc), "Bilverkstan Huddinge", "Liten service", 30000),
+                new(new DateTime(2014, 6, 3, 0, 0, 0, DateTimeKind.Utc), "Bilverkstan Huddinge", "Liten service", 65000),
+                new(new DateTime(2018, 3, 20, 0, 0, 0, DateTimeKind.Utc), "DIY", "Oljebyte", 130000),
+                new(new DateTime(2021, 11, 5, 0, 0, 0, DateTimeKind.Utc), "DIY", "Liten service", 198000),
+            },
+            OwnerRecords = new List<OwnerRecord>
+            {
+                new(new DateTime(2010, 4, 5, 0, 0, 0, DateTimeKind.Utc), new DateTime(2012, 8, 15, 0, 0, 0, DateTimeKind.Utc), false, "Malmö"),
+                new(new DateTime(2012, 8, 15, 0, 0, 0, DateTimeKind.Utc), new DateTime(2015, 3, 1, 0, 0, 0, DateTimeKind.Utc), true, "Göteborg"),
+                new(new DateTime(2015, 3, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2018, 11, 20, 0, 0, 0, DateTimeKind.Utc), false, "Linköping"),
+                new(new DateTime(2018, 11, 20, 0, 0, 0, DateTimeKind.Utc), new DateTime(2022, 6, 10, 0, 0, 0, DateTimeKind.Utc), false, "Uppsala"),
+                new(new DateTime(2022, 6, 10, 0, 0, 0, DateTimeKind.Utc), null, false, "Huddinge"),
+            },
+            InsuranceIncidentRecords = new List<InsuranceIncidentRecord>
+            {
+                new(new DateTime(2014, 12, 3, 0, 0, 0, DateTimeKind.Utc), "Kollision", "Allvarlig"),
+                new(new DateTime(2017, 7, 19, 0, 0, 0, DateTimeKind.Utc), "Parkeringsskada", "Mindre"),
+                new(new DateTime(2022, 10, 28, 0, 0, 0, DateTimeKind.Utc), "Stöld av katalysator", "Medel"),
+            },
+            RecallRecords = new List<RecallRecord>
+            {
+                new(new DateTime(2016, 5, 10, 0, 0, 0, DateTimeKind.Utc), "Kontroll av krockkudde (Takata)", false),
+            },
+            DebtRecords = new List<DebtRecord>
+            {
+                new("Skatteskuld", 3500m, new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc)),
+            },
+            MileageReadings = new List<MileageReadingRecord>
+            {
+                new(new DateTime(2011, 4, 18, 0, 0, 0, DateTimeKind.Utc), 15000, "Besiktning"),
+                new(new DateTime(2012, 4, 22, 0, 0, 0, DateTimeKind.Utc), 30000, "Besiktning"),
+                new(new DateTime(2013, 5, 6, 0, 0, 0, DateTimeKind.Utc), 48000, "Besiktning"),
+                new(new DateTime(2014, 5, 12, 0, 0, 0, DateTimeKind.Utc), 65000, "Besiktning"),
+                new(new DateTime(2015, 5, 20, 0, 0, 0, DateTimeKind.Utc), 82000, "Besiktning"),
+                new(new DateTime(2016, 6, 8, 0, 0, 0, DateTimeKind.Utc), 98000, "Service"),
+                new(new DateTime(2017, 6, 1, 0, 0, 0, DateTimeKind.Utc), 115000, "Besiktning"),
+                new(new DateTime(2018, 3, 20, 0, 0, 0, DateTimeKind.Utc), 130000, "Service"),
+                new(new DateTime(2019, 6, 15, 0, 0, 0, DateTimeKind.Utc), 150000, "Besiktning"),
+                new(new DateTime(2020, 8, 10, 0, 0, 0, DateTimeKind.Utc), 168000, "Service"),
+                new(new DateTime(2021, 7, 2, 0, 0, 0, DateTimeKind.Utc), 198000, "Besiktning"),
+                // Suspicious mileage drop — possible odometer tampering
+                new(new DateTime(2022, 6, 10, 0, 0, 0, DateTimeKind.Utc), 185000, "Ägarebyte"),
+                new(new DateTime(2023, 7, 18, 0, 0, 0, DateTimeKind.Utc), 218000, "Besiktning"),
+                new(new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc), 245000, "Besiktning"),
+            },
+            SimilarCars = new List<MarketComparisonRecord>
+            {
+                new("Golf", 2009, 28000m),
+                new("Golf", 2010, 40000m),
+                new("Golf", 2011, 52000m),
+            },
+            KnownIssues = new List<string>
+            {
+                "DSG-låda kräver regelbundet oljebyte",
+                "Vattenpump/termostat vanligt problem",
+                "Mekatronik-enhet kan fallera",
+                "Turbo kan gå sönder vid 150 000 km",
+                "Injektorer kan börja läcka",
+                "Oljeförbrukning ökar efter 200 000 km",
+            },
+            SecurityFeatures = new List<string>(),
+            IsImported = false,
         }
     };
 


### PR DESCRIPTION
## Summary
- Each of the 12 analysis factors is now **clickable** — opens a right-side Sheet panel with detailed historical data
- **Backend**: New `AnalysisDetails` composite DTO with 8 record types (`InspectionRecord`, `ServiceRecord`, `OwnerRecord`, etc.), mapped from `CarDataResult` in `CarSearchService`. MockCarDataProvider enriched with detail data for all 5 test vehicles
- **Frontend**: `FactorDetailSheet` + `FactorDetailContent` components with tailored views per factor (tables, badges, timelines, progress bars, alerts)
- **Mileage tampering detection**: MNO345 (VW Golf) shows red-highlighted row when mileage decreases between readings

### Factor detail views
| Factor | Content |
|--------|---------|
| Besiktning | Table: date, pass/fail badge, remarks |
| Servicehistorik | Table: workshop, type, mileage |
| Ägarhistorik | Timeline: period, private/company, region |
| Försäkring | Incidents table or green "no incidents" |
| Återkallelser | List with resolved/pending badges |
| Skuld & ekonomi | Purchase block alert + debt table |
| Miljö & skatt | Key metrics (Euro class, CO₂, tax) |
| Marknadsvärde | Valuation + similar cars comparison |
| Drivlina | Reliability bar, known issues, repair cost |
| Stöld & säkerhet | Risk badge, NCAP stars, alarm, equipment |
| Ålder | Registration date, import status |
| Miltal | History table with red row on suspicious decrease |

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 285 tests passing
- [x] `npm run build` — 0 TypeScript errors
- [ ] Manual: search ABC123 → analysis → click each factor → verify Sheet content
- [ ] Manual: search MNO345 → mileage detail → verify red row for tampering

🤖 Generated with [Claude Code](https://claude.com/claude-code)