### PR TITLE
feat: Swedish UI — mil, equipment, tax, recommendations

### DIFF
--- a/frontend/src/features/car/car-analysis-page.tsx
+++ b/frontend/src/features/car/car-analysis-page.tsx
@@ -151,6 +151,12 @@ export function CarAnalysisPage() {
               besiktning, skuld, försäkring, servicehistorik, drivlina,
               återkallelser, ägarhistorik, marknadsvärde, miljö och säkerhet.
             </p>
+            <p className="mt-3 text-xs text-muted-foreground/70 italic">
+              Denna analys baseras uteslutande på tillgänglig fordonsdata och utgör inte
+              en bedömning av fordonets faktiska skick. En professionell besiktning
+              rekommenderas alltid innan köpbeslut. CarCheck ansvarar inte för fordonets
+              verkliga kondition.
+            </p>
           </CardContent>
         </Card>
       </div>

--- a/frontend/src/features/car/car-result-page.tsx
+++ b/frontend/src/features/car/car-result-page.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { BarChart3, Car, Fuel, Palette, Gauge, Heart } from 'lucide-react'
-import { formatSek, formatNumber } from '@/lib/format'
+import { formatSek, formatMil } from '@/lib/format'
 import { useCheckFavorite, useAddFavorite, useRemoveFavorite } from '@/hooks/use-favorites'
 import { useCarById } from '@/hooks/use-car-search'
 import { useQueryClient } from '@tanstack/react-query'
@@ -107,7 +107,7 @@ export function CarResultPage() {
               </div>
               <div className="flex justify-between">
                 <dt className="text-muted-foreground">Miltal</dt>
-                <dd className="font-medium">{formatNumber(car.mileage)} km</dd>
+                <dd className="font-medium">{formatMil(car.mileage)}</dd>
               </div>
             </dl>
           </CardContent>

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -23,6 +23,10 @@ export function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString('sv-SE')
 }
 
+export function formatMil(km: number): string {
+  return `${formatNumber(Math.round(km / 10))} mil`
+}
+
 export function getScoreColor(score: number): string {
   if (score >= 85) return 'text-green-600'
   if (score >= 70) return 'text-lime-600'

--- a/frontend/src/types/car.types.ts
+++ b/frontend/src/types/car.types.ts
@@ -123,4 +123,7 @@ export interface AnalysisDetails {
   firstRegistrationDate: string | null
   isImported: boolean | null
   mileageHistory: MileageReadingRecord[]
+  factoryEquipment: string[]
+  factoryOptions: string[]
+  taxWithoutBonusMalusSek: number | null
 }

--- a/src/CarCheck.Application/Cars/CarAnalysisEngine.cs
+++ b/src/CarCheck.Application/Cars/CarAnalysisEngine.cs
@@ -212,7 +212,7 @@ public class CarAnalysisEngine
         if (euroClass is null && co2EmissionsGPerKm is null && annualTaxSek is null) return 60; // Fallback
 
         // Electric vehicles get top score
-        if (fuelType?.Equals("Electric", StringComparison.OrdinalIgnoreCase) == true)
+        if (fuelType is not null && (fuelType.Equals("Electric", StringComparison.OrdinalIgnoreCase) || fuelType.Equals("El", StringComparison.OrdinalIgnoreCase)))
             return 100m;
 
         var score = (euroClass?.ToUpperInvariant()) switch
@@ -384,10 +384,10 @@ public class CarAnalysisEngine
 
     private static string GenerateRecommendation(decimal score) => score switch
     {
-        >= 85 => "Excellent condition. This vehicle appears to be a strong choice with minimal risk factors.",
-        >= 70 => "Good condition. The vehicle is generally sound with some minor considerations.",
-        >= 55 => "Fair condition. There are some factors to be aware of — consider a professional inspection.",
-        >= 40 => "Below average. Multiple risk factors present — proceed with caution and get a thorough inspection.",
-        _ => "Poor condition. Significant risk factors identified — we recommend exploring other options."
+        >= 85 => "Utmärkt skick. Fordonet verkar vara ett starkt val med minimala riskfaktorer.",
+        >= 70 => "Bra skick. Fordonet är generellt sunt med några mindre anmärkningar.",
+        >= 55 => "Godtagbart skick. Det finns faktorer att vara medveten om — en professionell besiktning rekommenderas.",
+        >= 40 => "Under genomsnittet. Flera riskfaktorer identifierade — gå vidare med försiktighet.",
+        _ => "Dåligt skick. Betydande riskfaktorer — vi rekommenderar att utforska andra alternativ."
     };
 }

--- a/src/CarCheck.Application/Cars/CarSearchService.cs
+++ b/src/CarCheck.Application/Cars/CarSearchService.cs
@@ -201,6 +201,9 @@ public class CarSearchService
             SecurityFeatures: data.SecurityFeatures ?? [],
             FirstRegistrationDate: data.FirstRegistrationDate,
             IsImported: data.IsImported,
-            MileageHistory: data.MileageReadings ?? []);
+            MileageHistory: data.MileageReadings ?? [],
+            FactoryEquipment: data.FactoryEquipment ?? [],
+            FactoryOptions: data.FactoryOptions ?? [],
+            TaxWithoutBonusMalusSek: data.TaxWithoutBonusMalusSek);
     }
 }

--- a/src/CarCheck.Application/Cars/DTOs/CarDTOs.cs
+++ b/src/CarCheck.Application/Cars/DTOs/CarDTOs.cs
@@ -76,4 +76,7 @@ public record AnalysisDetails(
     List<string> SecurityFeatures,
     DateTime? FirstRegistrationDate,
     bool? IsImported,
-    List<MileageReadingRecord> MileageHistory);
+    List<MileageReadingRecord> MileageHistory,
+    List<string> FactoryEquipment,
+    List<string> FactoryOptions,
+    decimal? TaxWithoutBonusMalusSek);

--- a/src/CarCheck.Application/Interfaces/ICarDataProvider.cs
+++ b/src/CarCheck.Application/Interfaces/ICarDataProvider.cs
@@ -70,4 +70,11 @@ public record CarDataResult(
     public List<string>? KnownIssues { get; init; }
     public List<string>? SecurityFeatures { get; init; }
     public bool? IsImported { get; init; }
+
+    // Equipment
+    public List<string>? FactoryEquipment { get; init; }
+    public List<string>? FactoryOptions { get; init; }
+
+    // Tax without bonus/malus
+    public decimal? TaxWithoutBonusMalusSek { get; init; }
 }

--- a/src/CarCheck.Infrastructure/External/MockCarDataProvider.cs
+++ b/src/CarCheck.Infrastructure/External/MockCarDataProvider.cs
@@ -71,6 +71,16 @@ public class MockCarDataProvider : ICarDataProvider
                 "Volvo On Call", "Startspärr", "Larm", "GPS-spårning",
             },
             IsImported = false,
+            FactoryEquipment = new List<string>
+            {
+                "Adaptiv farthållare", "Navigation", "Elstolar med minne",
+                "Panoramaglastak", "Parkeringskamera 360°", "Keyless entry",
+            },
+            FactoryOptions = new List<string>
+            {
+                "Dragkrok", "Vinterdäck monterade", "Luftfjädring",
+            },
+            TaxWithoutBonusMalusSek = 1_106m,
         },
 
         ["DEF456"] = new CarDataResult(
@@ -151,11 +161,21 @@ public class MockCarDataProvider : ICarDataProvider
                 "BMW Connected Drive", "Startspärr", "Larm",
             },
             IsImported = false,
+            FactoryEquipment = new List<string>
+            {
+                "Sportläderstolar", "Navigation Professional", "LED-strålkastare",
+                "Backkamera", "Parkeringssensorer fram och bak",
+            },
+            FactoryOptions = new List<string>
+            {
+                "M Sport-paket", "Harman Kardon-ljud",
+            },
+            TaxWithoutBonusMalusSek = 952m,
         },
 
         ["GHI789"] = new CarDataResult(
             "GHI789", "Toyota", "Corolla", 2015, 142000,
-            "Petrol", 132, "Silver",
+            "Bensin", 132, "Silver",
             InsuranceIncidents: 2, ManufacturerRecalls: 0,
             LastInspectionDate: DateTime.UtcNow.AddMonths(-14), InspectionPassed: false,
             MarketValueSek: 95000m)
@@ -230,11 +250,18 @@ public class MockCarDataProvider : ICarDataProvider
                 "Startspärr",
             },
             IsImported = false,
+            FactoryEquipment = new List<string>
+            {
+                "Klimatanläggning", "Bluetooth", "Farthållare",
+                "Backkamera",
+            },
+            FactoryOptions = new List<string>(),
+            TaxWithoutBonusMalusSek = 1_006m,
         },
 
         ["JKL012"] = new CarDataResult(
             "JKL012", "Tesla", "Model 3", 2023, 12000,
-            "Electric", 283, "Red",
+            "El", 283, "Red",
             InsuranceIncidents: 0, ManufacturerRecalls: 2,
             LastInspectionDate: DateTime.UtcNow.AddMonths(-1), InspectionPassed: true,
             MarketValueSek: 420000m)
@@ -295,11 +322,21 @@ public class MockCarDataProvider : ICarDataProvider
                 "Tesla Sentry Mode", "GPS-spårning", "Startspärr", "Mobilapp-lås",
             },
             IsImported = true,
+            FactoryEquipment = new List<string>
+            {
+                "Autopilot", "15\" pekskärm", "Värmepump",
+                "Glastak", "LED-strålkastare", "Trådlös mobilladdning",
+            },
+            FactoryOptions = new List<string>
+            {
+                "Enhanced Autopilot", "Vit inredning",
+            },
+            TaxWithoutBonusMalusSek = 360m,
         },
 
         ["MNO345"] = new CarDataResult(
             "MNO345", "Volkswagen", "Golf", 2010, 245000,
-            "Petrol", 105, "Blue",
+            "Bensin", 105, "Blue",
             InsuranceIncidents: 3, ManufacturerRecalls: 1,
             LastInspectionDate: DateTime.UtcNow.AddMonths(-26), InspectionPassed: false,
             MarketValueSek: 42000m)
@@ -391,6 +428,12 @@ public class MockCarDataProvider : ICarDataProvider
             },
             SecurityFeatures = new List<string>(),
             IsImported = false,
+            FactoryEquipment = new List<string>
+            {
+                "Klimatanläggning", "AUX-ingång",
+            },
+            FactoryOptions = new List<string>(),
+            TaxWithoutBonusMalusSek = 1_478m,
         }
     };
 

--- a/tests/CarCheck.Application.Tests/Cars/CarAnalysisEngineTests.cs
+++ b/tests/CarCheck.Application.Tests/Cars/CarAnalysisEngineTests.cs
@@ -428,7 +428,7 @@ public class CarAnalysisEngineTests
         var (score, recommendation, breakdown) = _sut.Analyze(data);
 
         Assert.True(score >= 85, $"Expected score >= 85 but got {score}");
-        Assert.Contains("Excellent", recommendation);
+        Assert.Contains("Utmärkt", recommendation);
         Assert.NotNull(breakdown);
     }
 
@@ -451,7 +451,7 @@ public class CarAnalysisEngineTests
         var (score, recommendation, breakdown) = _sut.Analyze(data);
 
         Assert.True(score < 40, $"Expected score < 40 but got {score}");
-        Assert.Contains("risk", recommendation, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("riskfaktorer", recommendation, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/CarCheck.Application.Tests/Cars/CarSearchServiceTests.cs
+++ b/tests/CarCheck.Application.Tests/Cars/CarSearchServiceTests.cs
@@ -142,7 +142,7 @@ public class CarSearchServiceTests
         var carId = Guid.NewGuid();
         var cachedAnalysis = new CarAnalysisResponse(
             Guid.NewGuid(), carId, "ABC123", "Volvo", "XC60", 2021,
-            88.5m, "Excellent condition.", new AnalysisBreakdown(90, 85, 100, 100, 100, 100, 80, 85, 90, 75, 80, 70),
+            88.5m, "Utmärkt skick. Fordonet verkar vara ett starkt val med minimala riskfaktorer.", new AnalysisBreakdown(90, 85, 100, 100, 100, 100, 80, 85, 90, 75, 80, 70),
             DateTime.UtcNow);
 
         _cacheService.GetAsync<CarAnalysisResponse>($"analysis:{carId}").Returns(cachedAnalysis);


### PR DESCRIPTION
## Summary
- **Miltal i mil**: Visar miltal i svenska mil (km÷10) istället för km — på bilsida, miltalshistorik och servicehistorik
- **Svenska bränslenamn**: Petrol→Bensin, Electric→El i mockdata
- **Fabriksutrustning**: Ny sektion under Ålder drill-down med fabriksutrustning och fabrikstillägg (badges)
- **Skatt med/utan bonus malus**: Miljö-detaljen visar nu både "Årsskatt (inkl. bonus/malus)" och "Grundskatt (exkl. bonus/malus)"
- **Svenska rekommendationer**: Analysmotor ger nu svenska textsträngar (Utmärkt/Bra/Godtagbart/Under genomsnittet/Dåligt skick)
- **Professionell disclaimer**: Under rekommendation-badge på analyssidan

## Changed files (12)
**Backend (7):** ICarDataProvider, CarDTOs, CarSearchService, CarAnalysisEngine, MockCarDataProvider + 2 testfiler
**Frontend (5):** car.types, format, car-result-page, car-analysis-page, factor-detail-content

## Test plan
- [x] `dotnet build` — 0 fel
- [x] `dotnet test` — 291 tester gröna
- [x] `npm run build` — 0 TS-fel
- [ ] Sök bil → Miltal i mil, bränsle = "Bensin"/"Diesel"/"El"
- [ ] Visa analys → Svensk rekommendation + disclaimer
- [ ] Klicka "Ålder" → Se fabriksutrustning + tillägg
- [ ] Klicka "Miljö & skatt" → Se skatt med och utan bonus malus
- [ ] Miltalshistorik + service → mil istället för km

🤖 Generated with [Claude Code](https://claude.com/claude-code)