### PR TITLE
feat: add React Error Boundary

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from '@/hooks/use-auth'
 import { Toaster } from '@/components/ui/sonner'
 import { router } from '@/routes/router'
+import { ErrorBoundary } from '@/components/common/error-boundary'
 
 // Apply saved theme before first render to avoid flash
 const savedTheme = localStorage.getItem('theme')
@@ -23,12 +24,14 @@ const queryClient = new QueryClient({
 
 function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <RouterProvider router={router} />
-        <Toaster />
-      </AuthProvider>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <RouterProvider router={router} />
+          <Toaster />
+        </AuthProvider>
+      </QueryClientProvider>
+    </ErrorBoundary>
   )
 }
 

--- a/frontend/src/components/common/error-boundary.tsx
+++ b/frontend/src/components/common/error-boundary.tsx
@@ -1,0 +1,45 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[ErrorBoundary]', error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 px-4 text-center dark:bg-slate-900">
+          <p className="mb-2 text-4xl">⚠️</p>
+          <h1 className="mb-2 text-xl font-bold text-slate-900 dark:text-white">
+            Något gick fel
+          </h1>
+          <p className="mb-6 text-sm text-slate-500 dark:text-slate-400">
+            Ett oväntat fel inträffade. Försök att ladda om sidan.
+          </p>
+          <button
+            onClick={() => window.location.reload()}
+            className="rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-blue-700"
+          >
+            Ladda om
+          </button>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}


### PR DESCRIPTION
Wraps the app root with an ErrorBoundary that catches render errors and shows a friendly reload UI instead of a blank screen.\n\nCloses #84