### PR TITLE
perf: route-based code splitting with React.lazy

### DIFF
--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -1,25 +1,39 @@
+import { lazy, Suspense } from 'react'
 import { createBrowserRouter } from 'react-router'
 import { ProtectedRoute } from './protected-route'
 import { PublicRoute } from './public-route'
 import { AppShell } from '@/components/layout/app-shell'
-import { LandingPage } from '@/features/landing/landing-page'
-import { LoginPage } from '@/features/auth/login-page'
-import { RegisterPage } from '@/features/auth/register-page'
-import { DashboardPage } from '@/features/dashboard/dashboard-page'
-import { CarResultPage } from '@/features/car/car-result-page'
-import { CarAnalysisPage } from '@/features/car/car-analysis-page'
-import { HistoryPage } from '@/features/history/history-page'
-import { FavoritesPage } from '@/features/favorites/favorites-page'
-import { BillingPage } from '@/features/billing/billing-page'
-import { SettingsPage } from '@/features/settings/settings-page'
+
+const LandingPage = lazy(() => import('@/features/landing/landing-page').then(m => ({ default: m.LandingPage })))
+const LoginPage = lazy(() => import('@/features/auth/login-page').then(m => ({ default: m.LoginPage })))
+const RegisterPage = lazy(() => import('@/features/auth/register-page').then(m => ({ default: m.RegisterPage })))
+const DashboardPage = lazy(() => import('@/features/dashboard/dashboard-page').then(m => ({ default: m.DashboardPage })))
+const CarResultPage = lazy(() => import('@/features/car/car-result-page').then(m => ({ default: m.CarResultPage })))
+const CarAnalysisPage = lazy(() => import('@/features/car/car-analysis-page').then(m => ({ default: m.CarAnalysisPage })))
+const HistoryPage = lazy(() => import('@/features/history/history-page').then(m => ({ default: m.HistoryPage })))
+const FavoritesPage = lazy(() => import('@/features/favorites/favorites-page').then(m => ({ default: m.FavoritesPage })))
+const BillingPage = lazy(() => import('@/features/billing/billing-page').then(m => ({ default: m.BillingPage })))
+const SettingsPage = lazy(() => import('@/features/settings/settings-page').then(m => ({ default: m.SettingsPage })))
+
+function PageLoader() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+    </div>
+  )
+}
+
+function Lazy({ children }: { children: React.ReactNode }) {
+  return <Suspense fallback={<PageLoader />}>{children}</Suspense>
+}
 
 export const router = createBrowserRouter([
   {
     element: <PublicRoute />,
     children: [
-      { path: '/', element: <LandingPage /> },
-      { path: '/login', element: <LoginPage /> },
-      { path: '/register', element: <RegisterPage /> },
+      { path: '/', element: <Lazy><LandingPage /></Lazy> },
+      { path: '/login', element: <Lazy><LoginPage /></Lazy> },
+      { path: '/register', element: <Lazy><RegisterPage /></Lazy> },
     ],
   },
   {
@@ -28,13 +42,13 @@ export const router = createBrowserRouter([
       {
         element: <AppShell />,
         children: [
-          { path: '/dashboard', element: <DashboardPage /> },
-          { path: '/car/:carId', element: <CarResultPage /> },
-          { path: '/car/:carId/analysis', element: <CarAnalysisPage /> },
-          { path: '/history', element: <HistoryPage /> },
-          { path: '/favorites', element: <FavoritesPage /> },
-          { path: '/billing', element: <BillingPage /> },
-          { path: '/settings', element: <SettingsPage /> },
+          { path: '/dashboard', element: <Lazy><DashboardPage /></Lazy> },
+          { path: '/car/:carId', element: <Lazy><CarResultPage /></Lazy> },
+          { path: '/car/:carId/analysis', element: <Lazy><CarAnalysisPage /></Lazy> },
+          { path: '/history', element: <Lazy><HistoryPage /></Lazy> },
+          { path: '/favorites', element: <Lazy><FavoritesPage /></Lazy> },
+          { path: '/billing', element: <Lazy><BillingPage /></Lazy> },
+          { path: '/settings', element: <Lazy><SettingsPage /></Lazy> },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- All 10 feature pages converted to `React.lazy()` imports
- Each route wrapped in `<Suspense>` with a centered spinner fallback
- Reduces initial JS bundle — users only download the chunk for the page they visit

## Test plan
- [ ] Navigate to `/` — landing page loads with no errors
- [ ] Navigate to `/login` and `/register` — pages load
- [ ] Log in and navigate to `/dashboard`, `/history`, `/favorites`, `/billing`, `/settings` — all load correctly
- [ ] Throttle network in DevTools → spinner briefly visible on first page visit

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)