### PR TITLE
refactor: centralize query keys with typed factory

### DIFF
--- a/frontend/src/hooks/use-billing.ts
+++ b/frontend/src/hooks/use-billing.ts
@@ -1,9 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { billingApi } from '@/api/billing.api'
+import { queryKeys } from '@/lib/query-keys'
 
 export function useTiers() {
   return useQuery({
-    queryKey: ['billing', 'tiers'],
+    queryKey: queryKeys.billing.tiers,
     queryFn: () => billingApi.getTiers().then((r) => r.data),
     staleTime: 30 * 60 * 1000,
   })
@@ -11,7 +12,7 @@ export function useTiers() {
 
 export function useSubscription() {
   return useQuery({
-    queryKey: ['billing', 'subscription'],
+    queryKey: queryKeys.billing.subscription,
     queryFn: () => billingApi.getSubscription().then((r) => r.data),
   })
 }
@@ -27,7 +28,7 @@ export function useCancelSubscription() {
   return useMutation({
     mutationFn: () => billingApi.cancelSubscription(),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['billing', 'subscription'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.billing.subscription })
     },
   })
 }

--- a/frontend/src/hooks/use-car-analysis.ts
+++ b/frontend/src/hooks/use-car-analysis.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
 import { carsApi } from '@/api/cars.api'
+import { queryKeys } from '@/lib/query-keys'
 
 export function useCarAnalysis(carId: string | undefined) {
   return useQuery({
-    queryKey: ['cars', carId, 'analysis'],
+    queryKey: queryKeys.cars.analysis(carId!),
     queryFn: () => carsApi.getAnalysis(carId!).then((r) => r.data),
     enabled: !!carId,
   })

--- a/frontend/src/hooks/use-car-search.ts
+++ b/frontend/src/hooks/use-car-search.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { carsApi } from '@/api/cars.api'
+import { queryKeys } from '@/lib/query-keys'
 import type { CarSearchRequest, CarSearchResponse } from '@/types/car.types'
 
 export function useCarSearch() {
@@ -7,14 +8,14 @@ export function useCarSearch() {
   return useMutation({
     mutationFn: (data: CarSearchRequest) => carsApi.search(data).then((r) => r.data),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['history'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.history.all })
     },
   })
 }
 
 export function useCarById(carId: string | undefined, initialData?: CarSearchResponse) {
   return useQuery({
-    queryKey: ['car', carId],
+    queryKey: queryKeys.cars.byId(carId!),
     queryFn: () => carsApi.getById(carId!).then((r) => r.data),
     enabled: !!carId,
     initialData,

--- a/frontend/src/hooks/use-favorites.ts
+++ b/frontend/src/hooks/use-favorites.ts
@@ -1,9 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { favoritesApi } from '@/api/favorites.api'
+import { queryKeys } from '@/lib/query-keys'
 
 export function useFavorites(page: number, pageSize = 20) {
   return useQuery({
-    queryKey: ['favorites', { page, pageSize }],
+    queryKey: queryKeys.favorites.list(page, pageSize),
     queryFn: () => favoritesApi.getFavorites({ page, pageSize }).then((r) => r.data),
     placeholderData: (prev) => prev,
   })
@@ -11,7 +12,7 @@ export function useFavorites(page: number, pageSize = 20) {
 
 export function useCheckFavorite(carId: string | undefined) {
   return useQuery({
-    queryKey: ['favorite-check', carId],
+    queryKey: queryKeys.favorites.check(carId!),
     queryFn: () => favoritesApi.checkFavorite(carId!).then((r) => r.data.isFavorite),
     enabled: !!carId,
   })
@@ -22,8 +23,8 @@ export function useAddFavorite() {
   return useMutation({
     mutationFn: (carId: string) => favoritesApi.addFavorite({ carId }).then((r) => r.data),
     onSuccess: (_data, carId) => {
-      void queryClient.invalidateQueries({ queryKey: ['favorites'] })
-      void queryClient.invalidateQueries({ queryKey: ['favorite-check', carId] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.favorites.all })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.favorites.check(carId) })
     },
   })
 }
@@ -33,8 +34,8 @@ export function useRemoveFavorite() {
   return useMutation({
     mutationFn: (carId: string) => favoritesApi.removeFavorite(carId),
     onSuccess: (_data, carId) => {
-      void queryClient.invalidateQueries({ queryKey: ['favorites'] })
-      void queryClient.invalidateQueries({ queryKey: ['favorite-check', carId] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.favorites.all })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.favorites.check(carId) })
     },
   })
 }

--- a/frontend/src/hooks/use-history.ts
+++ b/frontend/src/hooks/use-history.ts
@@ -1,9 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { historyApi } from '@/api/history.api'
+import { queryKeys } from '@/lib/query-keys'
 
 export function useHistory(page: number, pageSize = 20) {
   return useQuery({
-    queryKey: ['history', { page, pageSize }],
+    queryKey: queryKeys.history.list(page, pageSize),
     queryFn: () => historyApi.getHistory({ page, pageSize }).then((r) => r.data),
     placeholderData: (prev) => prev,
   })
@@ -14,7 +15,7 @@ export function useDeleteHistoryEntry() {
   return useMutation({
     mutationFn: (id: string) => historyApi.deleteEntry(id),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['history'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.history.all })
     },
   })
 }
@@ -24,7 +25,7 @@ export function useClearHistory() {
   return useMutation({
     mutationFn: () => historyApi.clearAll(),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['history'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.history.all })
     },
   })
 }

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -1,0 +1,20 @@
+export const queryKeys = {
+  cars: {
+    all: ['cars'] as const,
+    byId: (carId: string) => ['cars', carId] as const,
+    analysis: (carId: string) => ['cars', carId, 'analysis'] as const,
+  },
+  history: {
+    all: ['history'] as const,
+    list: (page: number, pageSize: number) => ['history', { page, pageSize }] as const,
+  },
+  favorites: {
+    all: ['favorites'] as const,
+    list: (page: number, pageSize: number) => ['favorites', { page, pageSize }] as const,
+    check: (carId: string) => ['favorites', 'check', carId] as const,
+  },
+  billing: {
+    tiers: ['billing', 'tiers'] as const,
+    subscription: ['billing', 'subscription'] as const,
+  },
+}


### PR DESCRIPTION
## Summary
- New file `frontend/src/lib/query-keys.ts` with a typed `queryKeys` factory
- All 5 hooks updated to import and use the factory instead of inline string arrays
- Invalidations in mutations now use the same typed keys (no typo risk)

## Test plan
- [ ] Build compiles without TypeScript errors
- [ ] Car search invalidates history correctly
- [ ] Add/remove favorite invalidates both list and check queries
- [ ] Cancel subscription invalidates subscription query

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)