### PR TITLE
refactor: memoize mileage history sort

### DIFF
--- a/frontend/src/features/car/components/factor-detail-content.tsx
+++ b/frontend/src/features/car/components/factor-detail-content.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Progress } from '@/components/ui/progress'
@@ -560,12 +561,14 @@ function AgeDetail({
 // ─── Miltal ───
 
 function MileageDetail({ readings }: { readings: AnalysisDetails['mileageHistory'] }) {
+  const sorted = useMemo(
+    () => [...readings].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()),
+    [readings]
+  )
+
   if (readings.length === 0) {
     return <EmptyState text="Ingen miltalshistorik tillgänglig." />
   }
-
-  // Sort by date ascending
-  const sorted = [...readings].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
 
   return (
     <div className="space-y-3">


### PR DESCRIPTION
## Summary
- `MileageDetail` in `factor-detail-content.tsx` now wraps the readings sort in `useMemo`
- Sort only re-runs when the `readings` prop reference changes, not on every parent render

## Test plan
- [ ] Car analysis page → mileage factor detail opens correctly
- [ ] Suspicious mileage drop still highlighted in red
- [ ] No console errors

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)