### PR TITLE
feat: dela analys via publik länk

### DIFF
--- a/frontend/src/api/cars.api.ts
+++ b/frontend/src/api/cars.api.ts
@@ -1,4 +1,5 @@
 import apiClient from './client'
+import axios from 'axios'
 import type { CarSearchRequest, CarSearchResponse, CarAnalysisResponse } from '@/types/car.types'
 
 export const carsApi = {
@@ -10,4 +11,7 @@ export const carsApi = {
 
   getAnalysis: (carId: string) =>
     apiClient.get<CarAnalysisResponse>(`/cars/${carId}/analysis`),
+
+  getPublicAnalysis: (carId: string) =>
+    axios.get<CarAnalysisResponse>(`/api/public/cars/${carId}/analysis`, { timeout: 10_000 }),
 }

--- a/frontend/src/features/car/car-analysis-page.tsx
+++ b/frontend/src/features/car/car-analysis-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import { useParams, Link } from 'react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -14,6 +14,7 @@ import {
   Shield,
   AlertTriangle,
   ChevronRight,
+  Share2,
 } from 'lucide-react'
 import { useCarAnalysis } from '@/hooks/use-car-analysis'
 import { LoadingSpinner } from '@/components/common/loading-spinner'
@@ -82,6 +83,15 @@ export function CarAnalysisPage() {
     key: keyof AnalysisBreakdown
     label: string
   } | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const handleShare = useCallback(() => {
+    const shareUrl = `${window.location.origin}/share/${carId}`
+    navigator.clipboard.writeText(shareUrl).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }, [carId])
 
   if (isLoading) return <LoadingSpinner />
   if (error) return <ErrorDisplay error={error} />
@@ -206,6 +216,10 @@ export function CarAnalysisPage() {
       <div className="flex gap-3">
         <Button variant="outline" asChild>
           <Link to="/dashboard">Ny sökning</Link>
+        </Button>
+        <Button variant="outline" onClick={handleShare}>
+          <Share2 className="mr-2 h-4 w-4" />
+          {copied ? 'Kopierad!' : 'Dela analys'}
         </Button>
       </div>
 

--- a/frontend/src/features/share/share-page.tsx
+++ b/frontend/src/features/share/share-page.tsx
@@ -1,0 +1,205 @@
+import { useParams, Link } from 'react-router'
+import { Car, BarChart3, Banknote, ClipboardList, Shield, ChevronRight } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Progress } from '@/components/ui/progress'
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+import { LoadingSpinner } from '@/components/common/loading-spinner'
+import { NegotiationTips } from '@/features/car/components/negotiation-tips'
+import { usePublicCarAnalysis } from '@/hooks/use-car-analysis'
+import { getScoreColor, getScoreBgColor } from '@/lib/format'
+import { cn } from '@/lib/utils'
+import type { AnalysisBreakdown } from '@/types/car.types'
+
+const FACTOR_GROUPS = [
+  {
+    title: 'Fordonets skick',
+    icon: <Car className="h-4 w-4" />,
+    items: [
+      { key: 'ageScore' as keyof AnalysisBreakdown, label: 'Ålder', weight: '12%' },
+      { key: 'mileageScore' as keyof AnalysisBreakdown, label: 'Miltal', weight: '12%' },
+      { key: 'inspectionScore' as keyof AnalysisBreakdown, label: 'Besiktning', weight: '10%' },
+    ],
+  },
+  {
+    title: 'Ekonomi & juridik',
+    icon: <Banknote className="h-4 w-4" />,
+    items: [
+      { key: 'debtFinanceScore' as keyof AnalysisBreakdown, label: 'Skuld & ekonomi', weight: '15%' },
+      { key: 'marketValueScore' as keyof AnalysisBreakdown, label: 'Marknadsvärde', weight: '5%' },
+      { key: 'environmentScore' as keyof AnalysisBreakdown, label: 'Miljö & skatt', weight: '5%' },
+    ],
+  },
+  {
+    title: 'Historik & underhåll',
+    icon: <ClipboardList className="h-4 w-4" />,
+    items: [
+      { key: 'insuranceScore' as keyof AnalysisBreakdown, label: 'Försäkring', weight: '9%' },
+      { key: 'serviceHistoryScore' as keyof AnalysisBreakdown, label: 'Servicehistorik', weight: '8%' },
+      { key: 'ownerHistoryScore' as keyof AnalysisBreakdown, label: 'Ägarhistorik', weight: '5%' },
+    ],
+  },
+  {
+    title: 'Säkerhet & tillförlitlighet',
+    icon: <Shield className="h-4 w-4" />,
+    items: [
+      { key: 'drivetrainScore' as keyof AnalysisBreakdown, label: 'Drivlina', weight: '8%' },
+      { key: 'recallScore' as keyof AnalysisBreakdown, label: 'Återkallelser', weight: '6%' },
+      { key: 'theftSecurityScore' as keyof AnalysisBreakdown, label: 'Stöld & säkerhet', weight: '5%' },
+    ],
+  },
+]
+
+export function SharePage() {
+  const { carId } = useParams<{ carId: string }>()
+  const { data: analysis, isLoading, error } = usePublicCarAnalysis(carId)
+
+  const scoreRounded = analysis ? Math.round(analysis.score) : 0
+  const hasPurchaseBlock = analysis?.breakdown.debtFinanceScore === 0
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
+      {/* Header */}
+      <header className="border-b bg-white dark:border-slate-800 dark:bg-slate-950">
+        <div className="mx-auto flex h-14 max-w-4xl items-center justify-between px-4">
+          <Link to="/" className="flex items-center gap-2 text-sm font-bold">
+            <Car className="h-4 w-4 text-blue-500" />
+            CarCheck
+          </Link>
+          <Button asChild size="sm">
+            <Link to="/register">Skapa konto gratis</Link>
+          </Button>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-4xl px-4 py-8">
+        {isLoading && <LoadingSpinner />}
+
+        {error && (
+          <div className="flex flex-col items-center justify-center py-24 text-center">
+            <p className="mb-2 text-4xl">404</p>
+            <h1 className="mb-2 text-xl font-bold">Analysen hittades inte</h1>
+            <p className="mb-6 text-sm text-muted-foreground">
+              Länken kan vara ogiltig eller så har analysen tagits bort.
+            </p>
+            <Button asChild>
+              <Link to="/">Tillbaka till startsidan</Link>
+            </Button>
+          </div>
+        )}
+
+        {analysis && (
+          <div className="space-y-6">
+            {/* Title */}
+            <div>
+              <h1 className="text-2xl font-bold">
+                {analysis.brand} {analysis.model} — Analys
+              </h1>
+              <p className="text-muted-foreground">{analysis.registrationNumber}</p>
+            </div>
+
+            {/* Purchase block */}
+            {hasPurchaseBlock && (
+              <Alert variant="destructive">
+                <AlertTitle>Köpspärr registrerad</AlertTitle>
+                <AlertDescription>
+                  Fordonet har en aktiv köpspärr hos Kronofogden. Köp avråds starkt.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {/* Score + Recommendation */}
+            <div className="grid gap-4 md:grid-cols-2">
+              <Card>
+                <CardContent className="flex flex-col items-center justify-center py-8">
+                  <div
+                    className={cn(
+                      'flex h-28 w-28 items-center justify-center rounded-full border-4',
+                      scoreRounded >= 70 ? 'border-green-500' : scoreRounded >= 40 ? 'border-yellow-500' : 'border-red-500'
+                    )}
+                  >
+                    <span className={cn('text-4xl font-bold', getScoreColor(scoreRounded))}>
+                      {scoreRounded}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm text-muted-foreground">av 100</p>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <BarChart3 className="h-4 w-4" />
+                    Rekommendation
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <Badge className={cn('text-sm px-3 py-1', getScoreBgColor(scoreRounded))}>
+                    {analysis.recommendation}
+                  </Badge>
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    Baserat på en viktad analys av tolv kategorier.
+                  </p>
+                  <p className="mt-3 text-xs italic text-muted-foreground/70">
+                    Analysen baseras på tillgänglig fordonsdata och ersätter inte en professionell besiktning.
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Negotiation tips */}
+            <NegotiationTips breakdown={analysis.breakdown} details={analysis.details} />
+
+            {/* Factor breakdown (read-only, no drill-down) */}
+            <div className="grid gap-4 md:grid-cols-2">
+              {FACTOR_GROUPS.map((group) => (
+                <Card key={group.title}>
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-base">
+                      {group.icon}
+                      {group.title}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-1">
+                    {group.items.map(({ key, label, weight }) => {
+                      const value = Math.round(analysis.breakdown[key])
+                      return (
+                        <div key={key} className="flex items-center gap-2 rounded-lg px-2 py-2.5">
+                          <div className="flex-1 space-y-1">
+                            <div className="flex items-center justify-between text-sm">
+                              <span className="font-medium">{label}</span>
+                              <span className="text-muted-foreground">{value}/100 ({weight})</span>
+                            </div>
+                            <Progress value={value} className="h-2" />
+                          </div>
+                          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/30" />
+                        </div>
+                      )
+                    })}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+
+            {/* CTA */}
+            <Card className="border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/30">
+              <CardContent className="flex flex-col items-center gap-4 py-8 text-center sm:flex-row sm:text-left">
+                <div className="flex-1">
+                  <h2 className="text-lg font-bold">Vill du göra en egen analys?</h2>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Skapa ett gratis konto och sök på vilken bil som helst — du får rekommendation,
+                    förhandlingstips och sparad historik.
+                  </p>
+                </div>
+                <Button asChild className="shrink-0">
+                  <Link to="/register">Kom igång gratis</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/hooks/use-car-analysis.ts
+++ b/frontend/src/hooks/use-car-analysis.ts
@@ -9,3 +9,11 @@ export function useCarAnalysis(carId: string | undefined) {
     enabled: !!carId,
   })
 }
+
+export function usePublicCarAnalysis(carId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.cars.publicAnalysis(carId!),
+    queryFn: () => carsApi.getPublicAnalysis(carId!).then((r) => r.data),
+    enabled: !!carId,
+  })
+}

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -3,6 +3,7 @@ export const queryKeys = {
     all: ['cars'] as const,
     byId: (carId: string) => ['cars', carId] as const,
     analysis: (carId: string) => ['cars', carId, 'analysis'] as const,
+    publicAnalysis: (carId: string) => ['cars', carId, 'public-analysis'] as const,
   },
   history: {
     all: ['history'] as const,

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -14,6 +14,7 @@ const HistoryPage = lazy(() => import('@/features/history/history-page').then(m 
 const FavoritesPage = lazy(() => import('@/features/favorites/favorites-page').then(m => ({ default: m.FavoritesPage })))
 const BillingPage = lazy(() => import('@/features/billing/billing-page').then(m => ({ default: m.BillingPage })))
 const SettingsPage = lazy(() => import('@/features/settings/settings-page').then(m => ({ default: m.SettingsPage })))
+const SharePage = lazy(() => import('@/features/share/share-page').then(m => ({ default: m.SharePage })))
 
 function PageLoader() {
   return (
@@ -34,6 +35,7 @@ export const router = createBrowserRouter([
       { path: '/', element: <Lazy><LandingPage /></Lazy> },
       { path: '/login', element: <Lazy><LoginPage /></Lazy> },
       { path: '/register', element: <Lazy><RegisterPage /></Lazy> },
+      { path: '/share/:carId', element: <Lazy><SharePage /></Lazy> },
     ],
   },
   {

--- a/src/CarCheck.API/Endpoints/PublicEndpoints.cs
+++ b/src/CarCheck.API/Endpoints/PublicEndpoints.cs
@@ -1,0 +1,23 @@
+using CarCheck.Application.Cars;
+
+namespace CarCheck.API.Endpoints;
+
+public static class PublicEndpoints
+{
+    public static void MapPublicEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/public").WithTags("Public");
+
+        // Returns a car analysis without requiring authentication.
+        // The carId GUID is unguessable, acting as a share token.
+        group.MapGet("/cars/{carId:guid}/analysis", async (Guid carId, CarSearchService carSearchService) =>
+        {
+            var result = await carSearchService.AnalyzeCarAsync(carId);
+            return result.IsSuccess
+                ? Results.Ok(result.Value)
+                : Results.NotFound(new { error = result.Error });
+        })
+        .AllowAnonymous()
+        .WithName("GetPublicCarAnalysis");
+    }
+}

--- a/src/CarCheck.API/Program.cs
+++ b/src/CarCheck.API/Program.cs
@@ -76,5 +76,6 @@ app.MapHistoryEndpoints();
 app.MapFavoriteEndpoints();
 app.MapBillingEndpoints();
 app.MapGdprEndpoints();
+app.MapPublicEndpoints();
 
 app.Run();


### PR DESCRIPTION
## Summary
- Nytt backend-endpoint `GET /api/public/cars/{carId}/analysis` (AllowAnonymous, ingen DB-migration)
- 'Dela analys'-knapp på `/car/:carId/analysis` kopierar share-URL till urklipp
- Ny publik sida `/share/:carId` — ingen inloggning krävs
- Share-sidan visar: poäng, rekommendation, förhandlingstips, 12-faktors breakdown (read-only)
- CTA på share-sidan driver nya registreringar
- Lazy-laddad med samma mönster som övriga sidor

## Hur det fungerar
1. Inloggad användare klickar 'Dela analys' → URL kopieras (`/share/{carId}`)
2. Länken skickas till vem som helst (SMS, Messenger, email)
3. Mottagaren öppnar länken utan inloggning och ser hela analysen + tips
4. CarCheck GUID-ID:n är 128-bitars och praktiskt taget omöjliga att gissa

## Test plan
- [ ] 'Dela analys'-knapp visas på analysidan
- [ ] Klick kopierar URL och visar 'Kopierad!' i 2 sekunder
- [ ] `/share/{carId}` öppnas utan inloggning
- [ ] 404 visas för ogiltigt carId
- [ ] CTA-länk till `/register` fungerar
- [ ] Mörkt/ljust tema på share-sidan

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)