### PR TITLE
feat: PWA-stöd med manifest och service worker

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,10 +1,18 @@
 <!doctype html>
-<html lang="en">
+<html lang="sv">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>CarCheck — Trygg bilanalys</title>
+    <meta name="description" content="Analysera vilken begagnad bil som helst med 12 faktorer och få en tydlig köprekommendation." />
+    <meta name="theme-color" content="#0f172a" />
+
+    <!-- PWA -->
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="apple-touch-icon" href="/icons/icon-192.svg" />
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="8" fill="#1e3a5f"/>
+  <path d="M6 20l2-6h16l2 6" stroke="#60a5fa" stroke-width="1.5" stroke-linecap="round"/>
+  <rect x="5" y="20" width="22" height="5" rx="2" fill="#2563eb"/>
+  <circle cx="10" cy="25" r="2.5" fill="#0f172a" stroke="#60a5fa" stroke-width="1.2"/>
+  <circle cx="22" cy="25" r="2.5" fill="#0f172a" stroke="#60a5fa" stroke-width="1.2"/>
+  <path d="M13 17h6" stroke="#93c5fd" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/icons/icon-192.svg
+++ b/frontend/public/icons/icon-192.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" fill="none">
+  <rect width="192" height="192" rx="40" fill="#1e3a5f"/>
+  <path d="M36 120l12-36h96l12 36" stroke="#60a5fa" stroke-width="8" stroke-linecap="round"/>
+  <rect x="30" y="120" width="132" height="30" rx="12" fill="#2563eb"/>
+  <circle cx="60" cy="150" r="15" fill="#0f172a" stroke="#60a5fa" stroke-width="7"/>
+  <circle cx="132" cy="150" r="15" fill="#0f172a" stroke="#60a5fa" stroke-width="7"/>
+  <path d="M78 102h36" stroke="#93c5fd" stroke-width="7" stroke-linecap="round"/>
+  <text x="96" y="75" font-family="system-ui,sans-serif" font-size="22" font-weight="800" fill="#ffffff" text-anchor="middle">CarCheck</text>
+</svg>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,39 @@
+{
+  "name": "CarCheck",
+  "short_name": "CarCheck",
+  "description": "Analysera begagnade bilar med 12 faktorer och få en tydlig köprekommendation.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "orientation": "portrait-primary",
+  "lang": "sv",
+  "icons": [
+    {
+      "src": "/icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-192.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Sök bil",
+      "short_name": "Sök",
+      "url": "/dashboard",
+      "description": "Sök på ett registreringsnummer"
+    },
+    {
+      "name": "Jämför bilar",
+      "short_name": "Jämför",
+      "url": "/compare",
+      "description": "Jämför två bilar sida vid sida"
+    }
+  ]
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,55 @@
+const CACHE_NAME = 'carcheck-v1'
+
+// Assets to cache on install
+const PRECACHE_URLS = [
+  '/',
+  '/manifest.json',
+]
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+  )
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+    )
+  )
+  self.clients.claim()
+})
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event
+  const url = new URL(request.url)
+
+  // Never cache API calls — always go to network
+  if (url.pathname.startsWith('/api')) {
+    event.respondWith(fetch(request))
+    return
+  }
+
+  // Network-first for navigation (HTML), cache fallback
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request).catch(() => caches.match('/'))
+    )
+    return
+  }
+
+  // Cache-first for static assets (JS, CSS, fonts, images)
+  event.respondWith(
+    caches.match(request).then(
+      (cached) => cached ?? fetch(request).then((response) => {
+        if (response.ok) {
+          const clone = response.clone()
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone))
+        }
+        return response
+      })
+    )
+  )
+})

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,3 +8,12 @@ createRoot(document.getElementById('root')!).render(
     <App />
   </StrictMode>,
 )
+
+// Register service worker for PWA support
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(() => {
+      // Service worker registration failed — app still works normally
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- `manifest.json`: appnamn, temafärg, SVG-ikoner, genvägar (Sök + Jämför)
- `sw.js`: service worker med network-first för navigation, cache-first för statiska resurser, alltid network för `/api`
- Service worker registreras i `main.tsx` vid sidladdning
- `index.html` uppdaterad: svensk titel/beskrivning, `theme-color`, manifest-länk, apple-touch-icon
- Eget SVG-favicon som ersätter Vite-standardikonen

## Beteende
- Android Chrome: visar "Lägg till på hemskärmen" efter ett besök
- iOS Safari: stöder apple-touch-icon för hemskärmsikon
- Offline: navigering faller tillbaka på cachad startsida, API-anrop misslyckas tydligt

## Test plan
- [ ] Chrome DevTools → Application → Manifest visar rätt data
- [ ] Service Worker registreras utan fel
- [ ] Android: "Lägg till på hemskärmen" visas
- [ ] Favicon syns i webbläsarfliken
- [ ] API-anrop går alltid till nätverket (ej cachade)

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)