### PR TITLE
feat: Blocket/Bytbil URL-klistring — extrahera regnummer från annons-URL

### DIFF
--- a/frontend/src/features/car/components/negotiation-tips.tsx
+++ b/frontend/src/features/car/components/negotiation-tips.tsx
@@ -4,7 +4,7 @@ import type { AnalysisBreakdown, AnalysisDetails } from '@/types/car.types'
 
 interface Props {
   breakdown: AnalysisBreakdown
-  details: AnalysisDetails
+  details: AnalysisDetails | null
 }
 
 interface Tip {
@@ -12,7 +12,8 @@ interface Tip {
   priority: 'high' | 'medium' | 'low'
 }
 
-function buildTips(breakdown: AnalysisBreakdown, details: AnalysisDetails): Tip[] {
+function buildTips(breakdown: AnalysisBreakdown, details: AnalysisDetails | null): Tip[] {
+  if (!details) return []
   const tips: Tip[] = []
 
   // ── Köpspärr ──

--- a/frontend/src/features/dashboard/components/search-form.tsx
+++ b/frontend/src/features/dashboard/components/search-form.tsx
@@ -1,10 +1,9 @@
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { Search } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { Search, Link as LinkIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { carSearchSchema, type CarSearchFormData } from '@/lib/validators'
+import { parseRegFromUrl, isUrl } from '@/lib/parse-reg-from-url'
 
 interface SearchFormProps {
   onSearch: (regNumber: string) => void
@@ -12,34 +11,93 @@ interface SearchFormProps {
 }
 
 export function SearchForm({ onSearch, isLoading }: SearchFormProps) {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<CarSearchFormData>({
-    resolver: zodResolver(carSearchSchema),
-  })
+  const [value, setValue] = useState('')
+  const [urlHint, setUrlHint] = useState<string | null>(null)
+  const [urlError, setUrlError] = useState(false)
+  const [regError, setRegError] = useState(false)
 
-  const onSubmit = (data: CarSearchFormData) => {
-    onSearch(data.registrationNumber.toUpperCase().replace(/\s/g, ''))
+  useEffect(() => {
+    if (isUrl(value)) {
+      const reg = parseRegFromUrl(value)
+      if (reg) {
+        setUrlHint(reg)
+        setUrlError(false)
+      } else {
+        setUrlHint(null)
+        setUrlError(true)
+      }
+    } else {
+      setUrlHint(null)
+      setUrlError(false)
+    }
+  }, [value])
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmed = value.trim()
+    if (!trimmed) return
+
+    let reg: string
+    if (isUrl(trimmed)) {
+      const parsed = parseRegFromUrl(trimmed)
+      if (!parsed) return
+      reg = parsed
+    } else {
+      reg = trimmed.toUpperCase().replace(/\s/g, '')
+      if (!/^[A-Z]{3}\d{3}$/.test(reg)) {
+        setRegError(true)
+        return
+      }
+    }
+
+    setRegError(false)
+    onSearch(reg)
   }
 
+  const isInputUrl = isUrl(value)
+
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row sm:items-end">
       <div className="flex-1 space-y-2">
-        <Label htmlFor="regNumber">Registreringsnummer</Label>
-        <Input
-          id="regNumber"
-          placeholder="ABC 123"
-          autoComplete="off"
-          className="uppercase"
-          {...register('registrationNumber')}
-        />
-        {errors.registrationNumber && (
-          <p className="text-sm text-destructive">{errors.registrationNumber.message}</p>
+        <Label htmlFor="regNumber">Registreringsnummer eller annons-URL</Label>
+        <div className="relative">
+          {isInputUrl && (
+            <LinkIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-blue-400" />
+          )}
+          <Input
+            id="regNumber"
+            placeholder="ABC 123 eller klistra in Blocket/Bytbil-länk"
+            autoComplete="off"
+            className={isInputUrl ? 'pl-9 font-normal' : 'uppercase'}
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value)
+              setRegError(false)
+            }}
+          />
+        </div>
+        {urlHint && (
+          <p className="flex items-center gap-1.5 text-sm text-blue-500">
+            <LinkIcon className="h-3.5 w-3.5" />
+            Hittade regnummer: <strong>{urlHint.slice(0, 3)} {urlHint.slice(3)}</strong>
+          </p>
+        )}
+        {urlError && (
+          <p className="text-sm text-destructive">
+            Kunde inte hitta ett regnummer i länken. Ange regnumret manuellt (t.ex. ABC 123).
+          </p>
+        )}
+        {regError && (
+          <p className="text-sm text-destructive">
+            Ogiltigt regnummer. Använd formatet ABC 123.
+          </p>
         )}
       </div>
-      <Button type="submit" disabled={isLoading} className="sm:w-auto">
+      <Button
+        type="submit"
+        disabled={isLoading || urlError || (isInputUrl && !urlHint)}
+        className="sm:w-auto"
+      >
         {isLoading ? (
           <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
         ) : (

--- a/frontend/src/lib/parse-reg-from-url.ts
+++ b/frontend/src/lib/parse-reg-from-url.ts
@@ -1,0 +1,27 @@
+/**
+ * Parses a Swedish registration number from a car ad URL (Blocket, Bytbil, etc.)
+ * Swedish reg format: 3 letters + 3 digits (e.g. ABC 123 or ABC123)
+ * New format also supports 3 letters + 2 digits + 1 letter (e.g. ABC12D) but is rare.
+ */
+export function parseRegFromUrl(input: string): string | null {
+  if (!input.startsWith('http://') && !input.startsWith('https://')) return null
+
+  try {
+    const url = new URL(input)
+    // Combine pathname + search to maximise chance of finding the reg number
+    const text = (url.pathname + url.search).toLowerCase()
+
+    // Swedish reg number pattern: 3 letters + optional separator + 3 digits
+    // In URL slugs they typically appear as "abc-123", "abc_123", or "abc123"
+    const match = text.match(/\b([a-z]{3})[-_ ]?(\d{3})\b/)
+    if (!match) return null
+
+    return (match[1] + match[2]).toUpperCase()
+  } catch {
+    return null
+  }
+}
+
+export function isUrl(value: string): boolean {
+  return value.startsWith('http://') || value.startsWith('https://')
+}

--- a/frontend/src/routes/protected-route.tsx
+++ b/frontend/src/routes/protected-route.tsx
@@ -1,9 +1,8 @@
-import { Navigate, Outlet, useLocation } from 'react-router'
+import { Navigate, Outlet } from 'react-router'
 import { useAuth } from '@/hooks/use-auth'
 
 export function ProtectedRoute() {
   const { isAuthenticated, isLoading } = useAuth()
-  const location = useLocation()
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Sammanfattning
- Sökinputfältet på dashboard accepterar nu annons-URL:er från Blocket och Bytbil
- Länkikon visas i fältet när en URL detekteras
- Regnumret extraheras automatiskt med regex och visas som hint: **ABC 123 hittades**
- Felmeddelande visas om regnummer ej hittas i URL:en
- Fixar preexisterande TypeScript-fel (NegotiationTips, ProtectedRoute)

## Testplan
- [ ] Klistra in Blocket-URL med regnummer i URL-slug → regnummer hittas och söks
- [ ] Klistra in URL utan regnummer → felmeddelande visas
- [ ] Skriv regnummer manuellt → fungerar som tidigare
- [ ] Felaktigt regnummerformat → valideringsfel visas

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)