### PR TITLE
feat: Sökintressemätare — visa hur manga sökt pa bilen

### DIFF
--- a/frontend/src/features/car/car-analysis-page.tsx
+++ b/frontend/src/features/car/car-analysis-page.tsx
@@ -15,6 +15,7 @@ import {
   AlertTriangle,
   ChevronRight,
   Share2,
+  Users,
 } from 'lucide-react'
 import { useCarAnalysis } from '@/hooks/use-car-analysis'
 import { LoadingSpinner } from '@/components/common/loading-spinner'
@@ -115,7 +116,15 @@ export function CarAnalysisPage() {
           <h1 className="text-2xl font-bold">
             {analysis.brand} {analysis.model} — Analys
           </h1>
-          <p className="text-muted-foreground">{analysis.registrationNumber}</p>
+          <div className="flex items-center gap-3 flex-wrap">
+            <p className="text-muted-foreground">{analysis.registrationNumber}</p>
+            {analysis.searchCount > 0 && (
+              <span className="flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-950/40 dark:text-blue-300">
+                <Users className="h-3 w-3" />
+                {analysis.searchCount} {analysis.searchCount === 1 ? 'person' : 'personer'} har sökt på denna bil
+              </span>
+            )}
+          </div>
         </div>
       </div>
 

--- a/frontend/src/types/car.types.ts
+++ b/frontend/src/types/car.types.ts
@@ -28,6 +28,7 @@ export interface CarAnalysisResponse {
   breakdown: AnalysisBreakdown
   createdAt: string
   details: AnalysisDetails | null
+  searchCount: number
 }
 
 export interface AnalysisBreakdown {

--- a/src/CarCheck.Application/Cars/CarSearchService.cs
+++ b/src/CarCheck.Application/Cars/CarSearchService.cs
@@ -135,6 +135,9 @@ public class CarSearchService
         var analysisResult = AnalysisResult.Create(carId, score, recommendation);
         await _analysisResultRepository.AddAsync(analysisResult, cancellationToken);
 
+        // Fetch search count for interest meter
+        var searchCount = await _searchHistoryRepository.GetSearchCountByCarIdAsync(carId, cancellationToken);
+
         var analysisResponse = new CarAnalysisResponse(
             analysisResult.Id,
             carId,
@@ -146,7 +149,8 @@ public class CarSearchService
             recommendation,
             breakdown,
             analysisResult.CreatedAt,
-            details);
+            details,
+            searchCount);
 
         await _cacheService.SetAsync(analysisCacheKey, analysisResponse, CacheDuration, cancellationToken);
 

--- a/src/CarCheck.Application/Cars/DTOs/CarDTOs.cs
+++ b/src/CarCheck.Application/Cars/DTOs/CarDTOs.cs
@@ -25,7 +25,8 @@ public record CarAnalysisResponse(
     string Recommendation,
     AnalysisBreakdown Breakdown,
     DateTime CreatedAt,
-    AnalysisDetails? Details = null);
+    AnalysisDetails? Details = null,
+    int SearchCount = 0);
 
 public record AnalysisBreakdown(
     decimal AgeScore,

--- a/src/CarCheck.Domain/Interfaces/ISearchHistoryRepository.cs
+++ b/src/CarCheck.Domain/Interfaces/ISearchHistoryRepository.cs
@@ -6,6 +6,7 @@ public interface ISearchHistoryRepository
 {
     Task<IReadOnlyList<SearchHistory>> GetByUserIdAsync(Guid userId, int page, int pageSize, CancellationToken cancellationToken = default);
     Task<int> GetCountByUserIdTodayAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task<int> GetSearchCountByCarIdAsync(Guid carId, CancellationToken cancellationToken = default);
     Task AddAsync(SearchHistory entry, CancellationToken cancellationToken = default);
     Task<SearchHistory?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task DeleteByIdAsync(Guid id, CancellationToken cancellationToken = default);

--- a/src/CarCheck.Infrastructure/Persistence/Repositories/SearchHistoryRepository.cs
+++ b/src/CarCheck.Infrastructure/Persistence/Repositories/SearchHistoryRepository.cs
@@ -31,6 +31,12 @@ public class SearchHistoryRepository : ISearchHistoryRepository
             .CountAsync(s => s.UserId == userId && s.SearchedAt >= todayUtc, cancellationToken);
     }
 
+    public async Task<int> GetSearchCountByCarIdAsync(Guid carId, CancellationToken cancellationToken = default)
+    {
+        return await _context.SearchHistories
+            .CountAsync(s => s.CarId == carId, cancellationToken);
+    }
+
     public async Task AddAsync(SearchHistory entry, CancellationToken cancellationToken = default)
     {
         await _context.SearchHistories.AddAsync(entry, cancellationToken);


### PR DESCRIPTION
## Sammanfattning

### Backend
- Ny metod `GetSearchCountByCarIdAsync` i `ISearchHistoryRepository` + `SearchHistoryRepository`
- `CarAnalysisResponse` DTO utökad med `SearchCount: int` (default 0)
- `CarSearchService.AnalyzeCarAsync` hämtar sökräknaren och inkluderar den i svaret

### Frontend
- TypeScript-typ `CarAnalysisResponse` uppdaterad med `searchCount: number`
- Blå badge bredvid regnumret på analyssidan: "X person(er) har sökt på denna bil"
- Visas bara om `searchCount > 0`

## Varför
Ger köparen psykologisk fördel: hög räknare = säljaren är motiverad (bilen legat länge), låg räknare = troligtvis ny annons. Absolut unikt — ingen konkurrent har denna funktion.

## Testplan
- [ ] Analysera en bil → räknaren ökar
- [ ] Sök samma bil flera gånger → räknaren visas
- [ ] Badge visas på analyssidan
- [ ] Ingen badge om räknaren är 0 (ny bil)

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)