### PR TITLE
feat: lösenordsåterställning (glömt lösenord-flöde)

### DIFF
--- a/backend/src/CarCheck.API/Endpoints/AuthEndpoints.cs
+++ b/backend/src/CarCheck.API/Endpoints/AuthEndpoints.cs
@@ -78,6 +78,24 @@ public static class AuthEndpoints
         })
         .WithName("ChangePassword")
         .RequireAuthorization();
+
+        group.MapPost("/forgot-password", async (PasswordResetRequest request, AuthService authService) =>
+        {
+            await authService.ForgotPasswordAsync(request);
+            return Results.Ok(new { message = "Om e-postadressen finns registrerad skickas en återställningslänk." });
+        })
+        .WithName("ForgotPassword")
+        .AllowAnonymous();
+
+        group.MapPost("/reset-password", async (PasswordResetConfirmRequest request, AuthService authService) =>
+        {
+            var result = await authService.ResetPasswordAsync(request);
+            return result.IsSuccess
+                ? Results.Ok(new { message = "Lösenordet har återställts. Du kan nu logga in." })
+                : Results.BadRequest(new { error = result.Error });
+        })
+        .WithName("ResetPassword")
+        .AllowAnonymous();
     }
 
     private static Guid? GetUserId(ClaimsPrincipal user)

--- a/backend/src/CarCheck.Application/Auth/AuthService.cs
+++ b/backend/src/CarCheck.Application/Auth/AuthService.cs
@@ -13,19 +13,22 @@ public class AuthService
     private readonly ITokenService _tokenService;
     private readonly IRefreshTokenRepository _refreshTokenRepository;
     private readonly ISecurityEventLogger _securityEventLogger;
+    private readonly IPasswordResetRepository _passwordResetRepository;
 
     public AuthService(
         IUserRepository userRepository,
         IPasswordHasher passwordHasher,
         ITokenService tokenService,
         IRefreshTokenRepository refreshTokenRepository,
-        ISecurityEventLogger securityEventLogger)
+        ISecurityEventLogger securityEventLogger,
+        IPasswordResetRepository passwordResetRepository)
     {
         _userRepository = userRepository;
         _passwordHasher = passwordHasher;
         _tokenService = tokenService;
         _refreshTokenRepository = refreshTokenRepository;
         _securityEventLogger = securityEventLogger;
+        _passwordResetRepository = passwordResetRepository;
     }
 
     public async Task<Result<UserResponse>> RegisterAsync(RegisterRequest request, CancellationToken cancellationToken = default)
@@ -120,6 +123,53 @@ public class AuthService
     {
         await _refreshTokenRepository.RevokeAllForUserAsync(userId, cancellationToken);
         await _securityEventLogger.LogAsync(userId, "LogoutAll", null, cancellationToken);
+
+        return Result<bool>.Success(true);
+    }
+
+    public async Task<Result<bool>> ForgotPasswordAsync(PasswordResetRequest request, CancellationToken cancellationToken = default)
+    {
+        var email = Email.Create(request.Email);
+        var user = await _userRepository.GetByEmailAsync(email, cancellationToken);
+
+        // Always return success to avoid user enumeration
+        if (user is null)
+            return Result<bool>.Success(true);
+
+        var reset = PasswordReset.Create(user.Id, TimeSpan.FromHours(1));
+        await _passwordResetRepository.AddAsync(reset, cancellationToken);
+
+        // TODO: Send email with reset link when SMTP is configured
+        // Reset URL: /reset-password?token={reset.Token}
+        Console.WriteLine($"[PASSWORD RESET] Token for {email.Value}: {reset.Token}");
+
+        await _securityEventLogger.LogAsync(user.Id, "PasswordResetRequested", null, cancellationToken);
+
+        return Result<bool>.Success(true);
+    }
+
+    public async Task<Result<bool>> ResetPasswordAsync(PasswordResetConfirmRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request.NewPassword.Length < 8)
+            return Result<bool>.Failure("Lösenordet måste vara minst 8 tecken.");
+
+        var reset = await _passwordResetRepository.GetByTokenAsync(request.Token, cancellationToken);
+
+        if (reset is null || reset.IsExpired() || reset.Used)
+            return Result<bool>.Failure("Ogiltig eller utgången länk. Begär en ny.");
+
+        var user = await _userRepository.GetByIdAsync(reset.UserId, cancellationToken);
+        if (user is null)
+            return Result<bool>.Failure("Användare hittades inte.");
+
+        reset.MarkUsed();
+        await _passwordResetRepository.UpdateAsync(reset, cancellationToken);
+
+        user.ChangePassword(_passwordHasher.Hash(request.NewPassword));
+        await _userRepository.UpdateAsync(user, cancellationToken);
+
+        await _refreshTokenRepository.RevokeAllForUserAsync(user.Id, cancellationToken);
+        await _securityEventLogger.LogAsync(user.Id, "PasswordReset", null, cancellationToken);
 
         return Result<bool>.Success(true);
     }

--- a/backend/src/CarCheck.Domain/Interfaces/IPasswordResetRepository.cs
+++ b/backend/src/CarCheck.Domain/Interfaces/IPasswordResetRepository.cs
@@ -1,0 +1,10 @@
+using CarCheck.Domain.Entities;
+
+namespace CarCheck.Domain.Interfaces;
+
+public interface IPasswordResetRepository
+{
+    Task AddAsync(PasswordReset reset, CancellationToken cancellationToken = default);
+    Task<PasswordReset?> GetByTokenAsync(string token, CancellationToken cancellationToken = default);
+    Task UpdateAsync(PasswordReset reset, CancellationToken cancellationToken = default);
+}

--- a/backend/src/CarCheck.Infrastructure/DependencyInjection.cs
+++ b/backend/src/CarCheck.Infrastructure/DependencyInjection.cs
@@ -40,6 +40,7 @@ public static class DependencyInjection
         services.AddScoped<IPasswordHasher, BcryptPasswordHasher>();
         services.AddScoped<ITokenService, JwtTokenService>();
         services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
+        services.AddScoped<IPasswordResetRepository, PasswordResetRepository>();
         services.AddScoped<ISecurityEventLogger, SecurityEventLogger>();
         services.AddScoped<AuthService>();
 

--- a/backend/src/CarCheck.Infrastructure/Persistence/Repositories/PasswordResetRepository.cs
+++ b/backend/src/CarCheck.Infrastructure/Persistence/Repositories/PasswordResetRepository.cs
@@ -1,0 +1,33 @@
+using CarCheck.Domain.Entities;
+using CarCheck.Domain.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace CarCheck.Infrastructure.Persistence.Repositories;
+
+public class PasswordResetRepository : IPasswordResetRepository
+{
+    private readonly CarCheckDbContext _context;
+
+    public PasswordResetRepository(CarCheckDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task AddAsync(PasswordReset reset, CancellationToken cancellationToken = default)
+    {
+        await _context.PasswordResets.AddAsync(reset, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<PasswordReset?> GetByTokenAsync(string token, CancellationToken cancellationToken = default)
+    {
+        return await _context.PasswordResets
+            .FirstOrDefaultAsync(p => p.Token == token, cancellationToken);
+    }
+
+    public async Task UpdateAsync(PasswordReset reset, CancellationToken cancellationToken = default)
+    {
+        _context.PasswordResets.Update(reset);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/backend/tests/CarCheck.Application.Tests/Auth/AuthServiceTests.cs
+++ b/backend/tests/CarCheck.Application.Tests/Auth/AuthServiceTests.cs
@@ -15,6 +15,7 @@ public class AuthServiceTests
     private readonly ITokenService _tokenService;
     private readonly IRefreshTokenRepository _refreshTokenRepository;
     private readonly ISecurityEventLogger _securityEventLogger;
+    private readonly IPasswordResetRepository _passwordResetRepository;
     private readonly AuthService _sut;
 
     public AuthServiceTests()
@@ -24,13 +25,15 @@ public class AuthServiceTests
         _tokenService = Substitute.For<ITokenService>();
         _refreshTokenRepository = Substitute.For<IRefreshTokenRepository>();
         _securityEventLogger = Substitute.For<ISecurityEventLogger>();
+        _passwordResetRepository = Substitute.For<IPasswordResetRepository>();
 
         _sut = new AuthService(
             _userRepository,
             _passwordHasher,
             _tokenService,
             _refreshTokenRepository,
-            _securityEventLogger);
+            _securityEventLogger,
+            _passwordResetRepository);
     }
 
     // ===== Register =====

--- a/frontend/src/api/auth.api.ts
+++ b/frontend/src/api/auth.api.ts
@@ -4,6 +4,8 @@ import type {
   LoginRequest,
   RefreshRequest,
   ChangePasswordRequest,
+  ForgotPasswordRequest,
+  ResetPasswordRequest,
   AuthResponse,
   UserResponse,
 } from '@/types/auth.types'
@@ -26,4 +28,10 @@ export const authApi = {
 
   changePassword: (data: ChangePasswordRequest) =>
     apiClient.post('/auth/change-password', data),
+
+  forgotPassword: (data: ForgotPasswordRequest) =>
+    apiClient.post('/auth/forgot-password', data),
+
+  resetPassword: (data: ResetPasswordRequest) =>
+    apiClient.post('/auth/reset-password', data),
 }

--- a/frontend/src/features/auth/forgot-password-page.tsx
+++ b/frontend/src/features/auth/forgot-password-page.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react'
+import { Link } from 'react-router'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Car, ArrowLeft, Mail } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { authApi } from '@/api/auth.api'
+import { forgotPasswordSchema, type ForgotPasswordFormData } from '@/lib/validators'
+
+export function ForgotPasswordPage() {
+  const [submitted, setSubmitted] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ForgotPasswordFormData>({
+    resolver: zodResolver(forgotPasswordSchema),
+  })
+
+  const onSubmit = async (data: ForgotPasswordFormData) => {
+    setIsSubmitting(true)
+    try {
+      await authApi.forgotPassword(data)
+    } finally {
+      // Always show confirmation regardless of outcome (security: no user enumeration)
+      setSubmitted(true)
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-12">
+      <div className="w-full max-w-sm space-y-8">
+
+        {/* Logo */}
+        <div className="flex items-center gap-2">
+          <Car className="h-5 w-5 text-blue-400" />
+          <span className="text-base font-bold">CarCheck</span>
+        </div>
+
+        {submitted ? (
+          <div className="space-y-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-600/10">
+              <Mail className="h-6 w-6 text-blue-400" />
+            </div>
+            <div className="space-y-1">
+              <h1 className="text-2xl font-bold">Kolla din e-post</h1>
+              <p className="text-sm text-muted-foreground">
+                Om e-postadressen finns registrerad har vi skickat en länk för att återställa lösenordet. Länken gäller i 1 timme.
+              </p>
+            </div>
+            <Link
+              to="/login"
+              className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Tillbaka till inloggning
+            </Link>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-1">
+              <h1 className="text-2xl font-bold">Glömt lösenord?</h1>
+              <p className="text-sm text-muted-foreground">
+                Ange din e-postadress så skickar vi en återställningslänk.
+              </p>
+            </div>
+
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="email">E-post</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="namn@exempel.se"
+                  autoComplete="email"
+                  autoFocus
+                  {...register('email')}
+                />
+                {errors.email && (
+                  <p className="text-sm text-destructive">{errors.email.message}</p>
+                )}
+              </div>
+
+              <Button
+                type="submit"
+                className="w-full bg-blue-600 hover:bg-blue-500"
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? 'Skickar...' : 'Skicka återställningslänk'}
+              </Button>
+            </form>
+
+            <Link
+              to="/login"
+              className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Tillbaka till inloggning
+            </Link>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/auth/login-page.tsx
+++ b/frontend/src/features/auth/login-page.tsx
@@ -157,7 +157,15 @@ export function LoginPage() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="password">Lösenord</Label>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="password">Lösenord</Label>
+                <Link
+                  to="/forgot-password"
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Glömt lösenord?
+                </Link>
+              </div>
               <Input
                 id="password"
                 type="password"

--- a/frontend/src/features/auth/reset-password-page.tsx
+++ b/frontend/src/features/auth/reset-password-page.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Car, ArrowLeft, CheckCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { authApi } from '@/api/auth.api'
+import { resetPasswordSchema, type ResetPasswordFormData } from '@/lib/validators'
+import type { AxiosError } from 'axios'
+import type { ApiError } from '@/types/api.types'
+
+export function ResetPasswordPage() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const token = searchParams.get('token') ?? ''
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [done, setDone] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ResetPasswordFormData>({
+    resolver: zodResolver(resetPasswordSchema),
+  })
+
+  if (!token) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
+        <div className="w-full max-w-sm space-y-4">
+          <Alert variant="destructive">
+            <AlertDescription>Ogiltig återställningslänk. Begär en ny.</AlertDescription>
+          </Alert>
+          <Link
+            to="/forgot-password"
+            className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Begär ny länk
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  const onSubmit = async (data: ResetPasswordFormData) => {
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      await authApi.resetPassword({ token, newPassword: data.newPassword })
+      setDone(true)
+    } catch (err) {
+      const axiosError = err as AxiosError<ApiError>
+      setError(axiosError.response?.data?.error || 'Något gick fel. Försök igen eller begär en ny länk.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-12">
+      <div className="w-full max-w-sm space-y-8">
+
+        {/* Logo */}
+        <div className="flex items-center gap-2">
+          <Car className="h-5 w-5 text-blue-400" />
+          <span className="text-base font-bold">CarCheck</span>
+        </div>
+
+        {done ? (
+          <div className="space-y-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-600/10">
+              <CheckCircle className="h-6 w-6 text-green-400" />
+            </div>
+            <div className="space-y-1">
+              <h1 className="text-2xl font-bold">Lösenordet återställt</h1>
+              <p className="text-sm text-muted-foreground">
+                Du kan nu logga in med ditt nya lösenord.
+              </p>
+            </div>
+            <Button
+              className="w-full bg-blue-600 hover:bg-blue-500"
+              onClick={() => navigate('/login')}
+            >
+              Logga in
+            </Button>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-1">
+              <h1 className="text-2xl font-bold">Skapa nytt lösenord</h1>
+              <p className="text-sm text-muted-foreground">
+                Välj ett nytt lösenord på minst 8 tecken.
+              </p>
+            </div>
+
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+              {error && (
+                <Alert variant="destructive">
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="newPassword">Nytt lösenord</Label>
+                <Input
+                  id="newPassword"
+                  type="password"
+                  autoComplete="new-password"
+                  autoFocus
+                  {...register('newPassword')}
+                />
+                {errors.newPassword && (
+                  <p className="text-sm text-destructive">{errors.newPassword.message}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="confirmPassword">Bekräfta lösenord</Label>
+                <Input
+                  id="confirmPassword"
+                  type="password"
+                  autoComplete="new-password"
+                  {...register('confirmPassword')}
+                />
+                {errors.confirmPassword && (
+                  <p className="text-sm text-destructive">{errors.confirmPassword.message}</p>
+                )}
+              </div>
+
+              <Button
+                type="submit"
+                className="w-full bg-blue-600 hover:bg-blue-500"
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? 'Sparar...' : 'Spara nytt lösenord'}
+              </Button>
+            </form>
+
+            <Link
+              to="/login"
+              className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Tillbaka till inloggning
+            </Link>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/validators.ts
+++ b/frontend/src/lib/validators.ts
@@ -35,7 +35,23 @@ export const carSearchSchema = z.object({
     .regex(/^[A-Za-z0-9 ]+$/, 'Endast bokstäver, siffror och mellanslag'),
 })
 
+export const forgotPasswordSchema = z.object({
+  email: z.string().email('Ange en giltig e-postadress'),
+})
+
+export const resetPasswordSchema = z
+  .object({
+    newPassword: z.string().min(8, 'Lösenordet måste vara minst 8 tecken'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: 'Lösenorden matchar inte',
+    path: ['confirmPassword'],
+  })
+
 export type LoginFormData = z.infer<typeof loginSchema>
 export type RegisterFormData = z.infer<typeof registerSchema>
 export type ChangePasswordFormData = z.infer<typeof changePasswordSchema>
 export type CarSearchFormData = z.infer<typeof carSearchSchema>
+export type ForgotPasswordFormData = z.infer<typeof forgotPasswordSchema>
+export type ResetPasswordFormData = z.infer<typeof resetPasswordSchema>

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -7,6 +7,8 @@ import { AppShell } from '@/components/layout/app-shell'
 const LandingPage = lazy(() => import('@/features/landing/landing-page').then(m => ({ default: m.LandingPage })))
 const LoginPage = lazy(() => import('@/features/auth/login-page').then(m => ({ default: m.LoginPage })))
 const RegisterPage = lazy(() => import('@/features/auth/register-page').then(m => ({ default: m.RegisterPage })))
+const ForgotPasswordPage = lazy(() => import('@/features/auth/forgot-password-page').then(m => ({ default: m.ForgotPasswordPage })))
+const ResetPasswordPage = lazy(() => import('@/features/auth/reset-password-page').then(m => ({ default: m.ResetPasswordPage })))
 const DashboardPage = lazy(() => import('@/features/dashboard/dashboard-page').then(m => ({ default: m.DashboardPage })))
 const CarResultPage = lazy(() => import('@/features/car/car-result-page').then(m => ({ default: m.CarResultPage })))
 const CarAnalysisPage = lazy(() => import('@/features/car/car-analysis-page').then(m => ({ default: m.CarAnalysisPage })))
@@ -36,6 +38,8 @@ export const router = createBrowserRouter([
       { path: '/', element: <Lazy><LandingPage /></Lazy> },
       { path: '/login', element: <Lazy><LoginPage /></Lazy> },
       { path: '/register', element: <Lazy><RegisterPage /></Lazy> },
+      { path: '/forgot-password', element: <Lazy><ForgotPasswordPage /></Lazy> },
+      { path: '/reset-password', element: <Lazy><ResetPasswordPage /></Lazy> },
       { path: '/share/:carId', element: <Lazy><SharePage /></Lazy> },
     ],
   },

--- a/frontend/src/types/auth.types.ts
+++ b/frontend/src/types/auth.types.ts
@@ -17,6 +17,15 @@ export interface ChangePasswordRequest {
   newPassword: string
 }
 
+export interface ForgotPasswordRequest {
+  email: string
+}
+
+export interface ResetPasswordRequest {
+  token: string
+  newPassword: string
+}
+
 export interface AuthResponse {
   accessToken: string
   refreshToken: string


### PR DESCRIPTION
Closes #122

## Backend
- `IPasswordResetRepository` + `PasswordResetRepository` (ny)
- `AuthService.ForgotPasswordAsync` — genererar token (1h), loggar till console (TODO: e-post)
- `AuthService.ResetPasswordAsync` — validerar token, uppdaterar lösenord, revokerar alla sessions
- `POST /api/auth/forgot-password` — returnerar alltid 200 (skyddar mot user enumeration)
- `POST /api/auth/reset-password` — returnerar 400 om token ogiltigt/utgånget/använt

## Frontend
- `/forgot-password` — e-postformulär + bekräftelsevy efter submit
- `/reset-password?token=` — nytt lösenord + bekräfta, success-vy med navigering till login
- "Glömt lösenord?"-länk vid lösenordsfältet på login-sidan

## Test plan
- [ ] Backend bygger utan fel
- [ ] `npx tsc --noEmit` passerar
- [ ] `/forgot-password` — fyller i e-post, får bekräftelse
- [ ] Token loggas i backend-konsolen (Development)
- [ ] `/reset-password?token=<token>` — sätter nytt lösenord, kan logga in

🤖 Generated with [Claude Code](https://claude.com/claude-code)