### PR TITLE
feat: GDPR-sidor och cookie-samtycke

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from '@/hooks/use-auth'
 import { Toaster } from '@/components/ui/sonner'
 import { router } from '@/routes/router'
 import { ErrorBoundary } from '@/components/common/error-boundary'
+import { CookieBanner } from '@/components/common/cookie-banner'
 
 // Apply saved theme before first render to avoid flash
 const savedTheme = localStorage.getItem('theme')
@@ -29,6 +30,7 @@ function App() {
         <AuthProvider>
           <RouterProvider router={router} />
           <Toaster />
+          <CookieBanner />
         </AuthProvider>
       </QueryClientProvider>
     </ErrorBoundary>

--- a/frontend/src/components/common/cookie-banner.tsx
+++ b/frontend/src/components/common/cookie-banner.tsx
@@ -1,0 +1,65 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router'
+import { Button } from '@/components/ui/button'
+import { X } from 'lucide-react'
+
+const COOKIE_KEY = 'cookie-consent'
+
+export function CookieBanner() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const consent = localStorage.getItem(COOKIE_KEY)
+    if (!consent) setVisible(true)
+  }, [])
+
+  const accept = () => {
+    localStorage.setItem(COOKIE_KEY, 'accepted')
+    setVisible(false)
+  }
+
+  const decline = () => {
+    localStorage.setItem(COOKIE_KEY, 'declined')
+    setVisible(false)
+  }
+
+  if (!visible) return null
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-background/95 backdrop-blur px-4 py-4 shadow-lg sm:px-6">
+      <div className="mx-auto flex max-w-4xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-muted-foreground">
+          Vi använder nödvändiga cookies för att hålla dig inloggad och spara dina inställningar.
+          Inga spårningscookies.{' '}
+          <Link to="/privacy" className="underline underline-offset-2 hover:text-foreground transition-colors">
+            Läs mer
+          </Link>
+        </p>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={decline}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            Avvisa
+          </Button>
+          <Button
+            size="sm"
+            onClick={accept}
+            className="bg-blue-600 hover:bg-blue-500"
+          >
+            Acceptera
+          </Button>
+          <button
+            onClick={decline}
+            className="ml-1 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Stäng"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/landing/landing-page.tsx
+++ b/frontend/src/features/landing/landing-page.tsx
@@ -132,12 +132,16 @@ export function LandingPage() {
       </main>
 
       {/* ── Footer ── */}
-      <footer className="relative z-10 flex items-center justify-between px-6 py-4 text-xs text-slate-700 md:px-10">
+      <footer className="relative z-10 flex flex-wrap items-center justify-between gap-2 px-6 py-4 text-xs text-slate-700 md:px-10">
         <div className="flex items-center gap-1.5 font-medium">
           <Car className="h-3.5 w-3.5" />
           CarCheck
         </div>
-        <p>&copy; {new Date().getFullYear()} CarCheck. Alla rättigheter förbehållna.</p>
+        <div className="flex items-center gap-4">
+          <Link to="/privacy" className="hover:text-slate-400 transition-colors">Integritetspolicy</Link>
+          <Link to="/terms" className="hover:text-slate-400 transition-colors">Användarvillkor</Link>
+          <p>&copy; {new Date().getFullYear()} CarCheck</p>
+        </div>
       </footer>
     </div>
   )

--- a/frontend/src/features/legal/privacy-page.tsx
+++ b/frontend/src/features/legal/privacy-page.tsx
@@ -1,0 +1,113 @@
+import { Link } from 'react-router'
+import { Car, ArrowLeft } from 'lucide-react'
+
+export function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-background px-4 py-12">
+      <div className="mx-auto max-w-2xl space-y-8">
+
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Car className="h-5 w-5 text-blue-400" />
+            <span className="text-base font-bold">CarCheck</span>
+          </div>
+          <Link
+            to="/"
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Tillbaka
+          </Link>
+        </div>
+
+        <div className="space-y-1">
+          <h1 className="text-3xl font-bold">Integritetspolicy</h1>
+          <p className="text-sm text-muted-foreground">Senast uppdaterad: mars 2026</p>
+        </div>
+
+        <div className="prose prose-sm dark:prose-invert max-w-none space-y-6 text-sm leading-relaxed text-muted-foreground [&_h2]:text-base [&_h2]:font-semibold [&_h2]:text-foreground [&_h2]:mt-6">
+
+          <p>
+            CarCheck ("vi", "oss", "tjänsten") värnar om din integritet. Den här policyn beskriver vilken
+            persondata vi samlar in, varför vi samlar in den och hur vi hanterar den.
+          </p>
+
+          <h2>1. Personuppgiftsansvarig</h2>
+          <p>
+            CarCheck är personuppgiftsansvarig för behandlingen av dina personuppgifter.
+            Kontakt: <span className="text-foreground">info@carcheck.se</span>
+          </p>
+
+          <h2>2. Vilken data vi samlar in</h2>
+          <p>Vi samlar in följande uppgifter när du använder tjänsten:</p>
+          <ul className="list-disc pl-5 space-y-1">
+            <li><strong className="text-foreground">Kontouppgifter</strong> — e-postadress och krypterat lösenord (bcrypt)</li>
+            <li><strong className="text-foreground">Sökhistorik</strong> — registreringsnummer du sökt på, tidpunkt</li>
+            <li><strong className="text-foreground">Favoriter</strong> — bilar du sparat som favoriter</li>
+            <li><strong className="text-foreground">Betalningsinformation</strong> — transaktionsstatus (vi lagrar inga kortuppgifter)</li>
+            <li><strong className="text-foreground">Säkerhetshändelser</strong> — inloggningsförsök, lösenordsbyten (för säkerhetsändamål)</li>
+            <li><strong className="text-foreground">Tekniska uppgifter</strong> — IP-adress (rate-limiting), session-tokens</li>
+          </ul>
+
+          <h2>3. Varför vi behandlar uppgifterna</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>För att tillhandahålla tjänsten (avtalsuppfyllelse)</li>
+            <li>För att säkra ditt konto och förhindra missbruk (berättigat intresse)</li>
+            <li>För att fullgöra rättsliga förpliktelser (t.ex. bokföring)</li>
+          </ul>
+
+          <h2>4. Lagringsplats och säkerhet</h2>
+          <p>
+            Din data lagras hos <strong className="text-foreground">Supabase</strong> på servrar inom EU
+            (eu-west-1, Irland). All kommunikation sker krypterat via HTTPS/TLS.
+            Lösenord lagras aldrig i klartext — vi använder bcrypt-hashing.
+          </p>
+
+          <h2>5. Hur länge vi sparar data</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>Kontodata — tills du raderar ditt konto</li>
+            <li>Sökhistorik — tills du rensar den eller raderar kontot</li>
+            <li>Säkerhetshändelser — 90 dagar</li>
+            <li>Inaktiva konton — raderas efter 24 månaders inaktivitet</li>
+          </ul>
+
+          <h2>6. Dina rättigheter (GDPR)</h2>
+          <p>Du har rätt att:</p>
+          <ul className="list-disc pl-5 space-y-1">
+            <li><strong className="text-foreground">Tillgång</strong> — begära ett utdrag av all din data (Inställningar → Exportera min data)</li>
+            <li><strong className="text-foreground">Radering</strong> — radera ditt konto och all tillhörande data (Inställningar → Radera konto)</li>
+            <li><strong className="text-foreground">Rättelse</strong> — kontakta oss för att rätta felaktig data</li>
+            <li><strong className="text-foreground">Invändning</strong> — invända mot behandling baserad på berättigat intresse</li>
+            <li><strong className="text-foreground">Klagomål</strong> — lämna klagomål till Integritetsskyddsmyndigheten (IMY)</li>
+          </ul>
+
+          <h2>7. Delning med tredje part</h2>
+          <p>
+            Vi säljer aldrig din data. Vi delar data enbart med underleverantörer som behövs för
+            att driva tjänsten (Supabase för databas). Dessa är bundna av databehandlingsavtal
+            och GDPR-krav.
+          </p>
+
+          <h2>8. Cookies</h2>
+          <p>
+            Vi använder enbart nödvändiga tekniska cookies och localStorage för att hålla dig inloggad
+            (session-token) och spara dina inställningar (tema). Inga spårningscookies eller
+            tredjeparts-annonsering används.
+          </p>
+
+          <h2>9. Ändringar</h2>
+          <p>
+            Vi kan uppdatera denna policy. Väsentliga ändringar meddelas via e-post eller
+            via tjänsten minst 30 dagar i förväg.
+          </p>
+
+          <h2>10. Kontakt</h2>
+          <p>
+            Frågor om din data? Kontakta oss på{' '}
+            <span className="text-foreground">info@carcheck.se</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/legal/terms-page.tsx
+++ b/frontend/src/features/legal/terms-page.tsx
@@ -1,0 +1,109 @@
+import { Link } from 'react-router'
+import { Car, ArrowLeft } from 'lucide-react'
+
+export function TermsPage() {
+  return (
+    <div className="min-h-screen bg-background px-4 py-12">
+      <div className="mx-auto max-w-2xl space-y-8">
+
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Car className="h-5 w-5 text-blue-400" />
+            <span className="text-base font-bold">CarCheck</span>
+          </div>
+          <Link
+            to="/"
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Tillbaka
+          </Link>
+        </div>
+
+        <div className="space-y-1">
+          <h1 className="text-3xl font-bold">Användarvillkor</h1>
+          <p className="text-sm text-muted-foreground">Senast uppdaterad: mars 2026</p>
+        </div>
+
+        <div className="prose prose-sm dark:prose-invert max-w-none space-y-6 text-sm leading-relaxed text-muted-foreground [&_h2]:text-base [&_h2]:font-semibold [&_h2]:text-foreground [&_h2]:mt-6">
+
+          <p>
+            Genom att använda CarCheck ("tjänsten") godkänner du dessa villkor. Läs dem
+            noggrant innan du skapar ett konto.
+          </p>
+
+          <h2>1. Om tjänsten</h2>
+          <p>
+            CarCheck tillhandahåller analysverktyg för begagnade bilar baserat på tillgänglig
+            offentlig information. Tjänsten är ett beslutsstöd — inte ett juridiskt eller
+            tekniskt intyg.
+          </p>
+
+          <h2>2. Ansvarsbegränsning</h2>
+          <p>
+            Analyserna baseras på tillgänglig data och är <strong className="text-foreground">inte garantier</strong> för
+            ett fordons faktiska skick, historia eller värde. CarCheck ansvarar inte för beslut
+            fattade baserat på tjänstens information. Genomför alltid en oberoende besiktning
+            innan köp.
+          </p>
+
+          <h2>3. Konto och åtkomst</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>Du måste vara minst 18 år för att skapa ett konto</li>
+            <li>Du ansvarar för att hålla ditt lösenord hemligt</li>
+            <li>Ett konto per person — delning av konton är inte tillåtet</li>
+            <li>Vi förbehåller oss rätten att stänga av konton som missbrukar tjänsten</li>
+          </ul>
+
+          <h2>4. Betalning och krediter</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>Krediter och prenumerationer är personliga och kan inte överlåtas</li>
+            <li>Köpta krediter är giltiga i 12 månader från köpdatum</li>
+            <li>Prenumerationer löper månadsvis och kan sägas upp när som helst</li>
+            <li>Återbetalning beviljas inte för förbrukade krediter eller påbörjad prenumerationsperiod</li>
+            <li>Priser anges i SEK inklusive moms</li>
+          </ul>
+
+          <h2>5. Tillåten användning</h2>
+          <p>Du får inte:</p>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>Skrapa eller automatisera förfrågningar mot tjänsten</li>
+            <li>Försöka kringgå rate-limiting eller kvotbegränsningar</li>
+            <li>Använda tjänsten för kommersiella ändamål utan skriftligt avtal</li>
+            <li>Dela, sälja eller vidarebefordra analysresultat i kommersiellt syfte</li>
+          </ul>
+
+          <h2>6. Immateriella rättigheter</h2>
+          <p>
+            Allt innehåll, kod och design i CarCheck tillhör CarCheck. Du beviljas en
+            begränsad, personlig, icke-exklusiv licens att använda tjänsten för privat bruk.
+          </p>
+
+          <h2>7. Tillgänglighet</h2>
+          <p>
+            Vi strävar efter hög tillgänglighet men garanterar inte avbrottsfri drift.
+            Planerat underhåll meddelas i förväg när möjligt.
+          </p>
+
+          <h2>8. Ändringar av villkor</h2>
+          <p>
+            Vi kan uppdatera dessa villkor. Väsentliga ändringar meddelas via e-post
+            minst 30 dagar i förväg. Fortsatt användning av tjänsten innebär att du
+            accepterar de uppdaterade villkoren.
+          </p>
+
+          <h2>9. Tillämplig lag</h2>
+          <p>
+            Dessa villkor regleras av svensk rätt. Tvister avgörs i svensk domstol.
+          </p>
+
+          <h2>10. Kontakt</h2>
+          <p>
+            Frågor om villkoren? Kontakta oss på{' '}
+            <span className="text-foreground">info@carcheck.se</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -9,6 +9,8 @@ const LoginPage = lazy(() => import('@/features/auth/login-page').then(m => ({ d
 const RegisterPage = lazy(() => import('@/features/auth/register-page').then(m => ({ default: m.RegisterPage })))
 const ForgotPasswordPage = lazy(() => import('@/features/auth/forgot-password-page').then(m => ({ default: m.ForgotPasswordPage })))
 const ResetPasswordPage = lazy(() => import('@/features/auth/reset-password-page').then(m => ({ default: m.ResetPasswordPage })))
+const PrivacyPage = lazy(() => import('@/features/legal/privacy-page').then(m => ({ default: m.PrivacyPage })))
+const TermsPage = lazy(() => import('@/features/legal/terms-page').then(m => ({ default: m.TermsPage })))
 const DashboardPage = lazy(() => import('@/features/dashboard/dashboard-page').then(m => ({ default: m.DashboardPage })))
 const CarResultPage = lazy(() => import('@/features/car/car-result-page').then(m => ({ default: m.CarResultPage })))
 const CarAnalysisPage = lazy(() => import('@/features/car/car-analysis-page').then(m => ({ default: m.CarAnalysisPage })))
@@ -40,6 +42,8 @@ export const router = createBrowserRouter([
       { path: '/register', element: <Lazy><RegisterPage /></Lazy> },
       { path: '/forgot-password', element: <Lazy><ForgotPasswordPage /></Lazy> },
       { path: '/reset-password', element: <Lazy><ResetPasswordPage /></Lazy> },
+      { path: '/privacy', element: <Lazy><PrivacyPage /></Lazy> },
+      { path: '/terms', element: <Lazy><TermsPage /></Lazy> },
       { path: '/share/:carId', element: <Lazy><SharePage /></Lazy> },
     ],
   },


### PR DESCRIPTION
Closes #123

## Ändringar

- `/privacy` — fullständig integritetspolicy på svenska (data, lagring, GDPR-rättigheter)
- `/terms` — användarvillkor (tjänstebeskrivning, ansvarsbegränsning, betalning)
- `CookieBanner` — visas för nya besökare, sparar val i localStorage, försvinner vid samtycke/avvisning
- Footer på landing-sidan med länkar till `/privacy` och `/terms`
- Bannern läggs in globalt i `App.tsx`

## Test plan
- [ ] `/privacy` renderas utan fel
- [ ] `/terms` renderas utan fel
- [ ] Cookie-banner visas vid första besök (rensa localStorage för att testa)
- [ ] Banner försvinner och återkommer inte efter klick
- [ ] Footer-länkarna på landing-sidan fungerar
- [ ] `npx tsc --noEmit` passerar

🤖 Generated with [Claude Code](https://claude.com/claude-code)