### PR TITLE
fix: pagination accuracy and password strength indicator

### DIFF
--- a/backend/src/CarCheck.Application/History/DTOs/HistoryDTOs.cs
+++ b/backend/src/CarCheck.Application/History/DTOs/HistoryDTOs.cs
@@ -13,4 +13,5 @@ public record SearchHistoryPageResponse(
     IReadOnlyList<SearchHistoryResponse> Items,
     int Page,
     int PageSize,
-    int TodayCount);
+    int TodayCount,
+    int TotalCount);

--- a/backend/src/CarCheck.Application/History/SearchHistoryService.cs
+++ b/backend/src/CarCheck.Application/History/SearchHistoryService.cs
@@ -26,6 +26,7 @@ public class SearchHistoryService
 
         var entries = await _searchHistoryRepository.GetByUserIdAsync(userId, page, pageSize, cancellationToken);
         var todayCount = await _searchHistoryRepository.GetCountByUserIdTodayAsync(userId, cancellationToken);
+        var totalCount = await _searchHistoryRepository.GetCountByUserIdAsync(userId, cancellationToken);
 
         var items = new List<SearchHistoryResponse>();
         foreach (var entry in entries)
@@ -42,7 +43,7 @@ public class SearchHistoryService
         }
 
         return Result<SearchHistoryPageResponse>.Success(
-            new SearchHistoryPageResponse(items, page, pageSize, todayCount));
+            new SearchHistoryPageResponse(items, page, pageSize, todayCount, totalCount));
     }
 
     public async Task<Result<bool>> DeleteEntryAsync(

--- a/backend/src/CarCheck.Domain/Interfaces/ISearchHistoryRepository.cs
+++ b/backend/src/CarCheck.Domain/Interfaces/ISearchHistoryRepository.cs
@@ -5,6 +5,7 @@ namespace CarCheck.Domain.Interfaces;
 public interface ISearchHistoryRepository
 {
     Task<IReadOnlyList<SearchHistory>> GetByUserIdAsync(Guid userId, int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<int> GetCountByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
     Task<int> GetCountByUserIdTodayAsync(Guid userId, CancellationToken cancellationToken = default);
     Task<int> GetSearchCountByCarIdAsync(Guid carId, CancellationToken cancellationToken = default);
     Task AddAsync(SearchHistory entry, CancellationToken cancellationToken = default);

--- a/backend/src/CarCheck.Infrastructure/Persistence/Repositories/SearchHistoryRepository.cs
+++ b/backend/src/CarCheck.Infrastructure/Persistence/Repositories/SearchHistoryRepository.cs
@@ -23,6 +23,12 @@ public class SearchHistoryRepository : ISearchHistoryRepository
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<int> GetCountByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await _context.SearchHistories
+            .CountAsync(s => s.UserId == userId, cancellationToken);
+    }
+
     public async Task<int> GetCountByUserIdTodayAsync(Guid userId, CancellationToken cancellationToken = default)
     {
         var todayUtc = DateTime.UtcNow.Date;

--- a/backend/tests/CarCheck.Application.Tests/History/SearchHistoryServiceTests.cs
+++ b/backend/tests/CarCheck.Application.Tests/History/SearchHistoryServiceTests.cs
@@ -29,6 +29,8 @@ public class SearchHistoryServiceTests
             .Returns(new List<SearchHistory> { entry });
         _searchHistoryRepository.GetCountByUserIdTodayAsync(userId, Arg.Any<CancellationToken>())
             .Returns(3);
+        _searchHistoryRepository.GetCountByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(1);
         _carRepository.GetByIdAsync(car.Id, Arg.Any<CancellationToken>())
             .Returns(car);
 
@@ -53,6 +55,8 @@ public class SearchHistoryServiceTests
             .Returns(new List<SearchHistory> { entry });
         _searchHistoryRepository.GetCountByUserIdTodayAsync(userId, Arg.Any<CancellationToken>())
             .Returns(1);
+        _searchHistoryRepository.GetCountByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(1);
         _carRepository.GetByIdAsync(carId, Arg.Any<CancellationToken>())
             .Returns((Car?)null);
 
@@ -73,6 +77,8 @@ public class SearchHistoryServiceTests
             .Returns(new List<SearchHistory>());
         _searchHistoryRepository.GetCountByUserIdTodayAsync(userId, Arg.Any<CancellationToken>())
             .Returns(0);
+        _searchHistoryRepository.GetCountByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(0);
 
         var result = await _sut.GetHistoryAsync(userId);
 
@@ -89,6 +95,8 @@ public class SearchHistoryServiceTests
         _searchHistoryRepository.GetByUserIdAsync(userId, 1, 100, Arg.Any<CancellationToken>())
             .Returns(new List<SearchHistory>());
         _searchHistoryRepository.GetCountByUserIdTodayAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(0);
+        _searchHistoryRepository.GetCountByUserIdAsync(userId, Arg.Any<CancellationToken>())
             .Returns(0);
 
         var result = await _sut.GetHistoryAsync(userId, page: 0, pageSize: 999);

--- a/frontend/src/features/auth/register-page.tsx
+++ b/frontend/src/features/auth/register-page.tsx
@@ -30,10 +30,25 @@ export function RegisterPage() {
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors },
   } = useForm<RegisterFormData>({
     resolver: zodResolver(registerSchema),
   })
+
+  const passwordValue = watch('password', '')
+  const passwordStrength = (() => {
+    if (!passwordValue) return 0
+    let score = 0
+    if (passwordValue.length >= 8) score++
+    if (passwordValue.length >= 12) score++
+    if (/[A-Z]/.test(passwordValue)) score++
+    if (/[0-9]/.test(passwordValue)) score++
+    if (/[^A-Za-z0-9]/.test(passwordValue)) score++
+    return score
+  })()
+  const strengthLabel = ['', 'Svagt', 'Svagt', 'Okej', 'Bra', 'Starkt'][passwordStrength]
+  const strengthColor = ['', 'bg-red-500', 'bg-orange-500', 'bg-yellow-500', 'bg-blue-500', 'bg-green-500'][passwordStrength]
 
   const onSubmit = async (data: RegisterFormData) => {
     setError(null)
@@ -163,6 +178,24 @@ export function RegisterPage() {
                 autoComplete="new-password"
                 {...register('password')}
               />
+              {passwordValue.length > 0 && (
+                <div className="space-y-1">
+                  <div className="flex gap-1">
+                    {[1, 2, 3, 4, 5].map((level) => (
+                      <div
+                        key={level}
+                        className={`h-1 flex-1 rounded-full transition-colors ${
+                          level <= passwordStrength ? strengthColor : 'bg-muted'
+                        }`}
+                      />
+                    ))}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Styrka: <span className="font-medium text-foreground">{strengthLabel}</span>
+                    {passwordValue.length < 8 && ' — minst 8 tecken krävs'}
+                  </p>
+                </div>
+              )}
               {errors.password && (
                 <p className="text-sm text-destructive">{errors.password.message}</p>
               )}

--- a/frontend/src/features/history/history-page.tsx
+++ b/frontend/src/features/history/history-page.tsx
@@ -118,7 +118,7 @@ export function HistoryPage() {
             {data && (
               <PaginationControls
                 page={page}
-                hasMore={data.items.length === 20}
+                hasMore={page * data.pageSize < data.totalCount}
                 onPageChange={setPage}
               />
             )}

--- a/frontend/src/types/history.types.ts
+++ b/frontend/src/types/history.types.ts
@@ -13,4 +13,5 @@ export interface SearchHistoryPageResponse {
   page: number
   pageSize: number
   todayCount: number
+  totalCount: number
 }


### PR DESCRIPTION
## Summary
- **Pagination (#3)**: Backend now returns `totalCount` for all user history entries. Frontend uses `page * pageSize < totalCount` instead of the broken `items.length === 20` heuristic — "Nästa"-knappen är nu korrekt inaktiverad på sista sidan, även om exakt 20 poster finns
- **Password strength (#7)**: Registreringssidan visar nu en 5-nivås styrkeindikator i realtid när användaren skriver lösenordet, med etiketter (Svagt/Okej/Bra/Starkt) och påminnelse om minst 8 tecken

## Test plan
- [ ] Historik: ha exakt 20 eller 40 poster — verifiera att "Nästa" visas/döljs korrekt
- [ ] Registrering: skriv in lösenord och se att styrkelinjen uppdateras live
- [ ] Registrering: kort lösenord (< 8 tecken) ska visa "minst 8 tecken krävs"
- [ ] Alla befintliga history-tester passerar (24 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)