### PR TITLE
feat: Stripe Checkout for subscriptions and credit packs

### DIFF
--- a/backend/src/CarCheck.API/Endpoints/BillingEndpoints.cs
+++ b/backend/src/CarCheck.API/Endpoints/BillingEndpoints.cs
@@ -1,6 +1,9 @@
 using System.Security.Claims;
-using CarCheck.Application.Billing;
 using CarCheck.Application.Billing.DTOs;
+using CarCheck.Domain.Enums;
+using Microsoft.Extensions.Configuration;
+using Stripe;
+using AppSubscriptionService = CarCheck.Application.Billing.SubscriptionService;
 
 namespace CarCheck.API.Endpoints;
 
@@ -10,7 +13,7 @@ public static class BillingEndpoints
     {
         var group = app.MapGroup("/api/billing").WithTags("Billing");
 
-        group.MapGet("/tiers", (SubscriptionService subscriptionService) =>
+        group.MapGet("/tiers", (AppSubscriptionService subscriptionService) =>
         {
             var tiers = subscriptionService.GetAvailableTiers();
             return Results.Ok(tiers);
@@ -18,7 +21,7 @@ public static class BillingEndpoints
         .WithName("GetTiers")
         .AllowAnonymous();
 
-        group.MapGet("/credit-packages", (SubscriptionService subscriptionService) =>
+        group.MapGet("/credit-packages", (AppSubscriptionService subscriptionService) =>
         {
             var packages = subscriptionService.GetCreditPackages();
             return Results.Ok(packages);
@@ -26,7 +29,7 @@ public static class BillingEndpoints
         .WithName("GetCreditPackages")
         .AllowAnonymous();
 
-        group.MapGet("/subscription", async (SubscriptionService subscriptionService, ClaimsPrincipal user) =>
+        group.MapGet("/subscription", async (AppSubscriptionService subscriptionService, ClaimsPrincipal user) =>
         {
             var userId = GetUserId(user);
             if (userId is null) return Results.Unauthorized();
@@ -39,7 +42,7 @@ public static class BillingEndpoints
         .WithName("GetSubscription")
         .RequireAuthorization();
 
-        group.MapPost("/checkout", async (SubscribeRequest request, SubscriptionService subscriptionService, ClaimsPrincipal user) =>
+        group.MapPost("/checkout", async (SubscribeRequest request, AppSubscriptionService subscriptionService, ClaimsPrincipal user) =>
         {
             var userId = GetUserId(user);
             if (userId is null) return Results.Unauthorized();
@@ -52,7 +55,7 @@ public static class BillingEndpoints
         .WithName("CreateCheckout")
         .RequireAuthorization();
 
-        group.MapPost("/buy-credits", async (BuyCreditsRequest request, SubscriptionService subscriptionService, ClaimsPrincipal user) =>
+        group.MapPost("/buy-credits", async (BuyCreditsRequest request, AppSubscriptionService subscriptionService, ClaimsPrincipal user) =>
         {
             var userId = GetUserId(user);
             if (userId is null) return Results.Unauthorized();
@@ -65,7 +68,7 @@ public static class BillingEndpoints
         .WithName("BuyCredits")
         .RequireAuthorization();
 
-        group.MapPost("/cancel", async (SubscriptionService subscriptionService, ClaimsPrincipal user) =>
+        group.MapPost("/cancel", async (AppSubscriptionService subscriptionService, ClaimsPrincipal user) =>
         {
             var userId = GetUserId(user);
             if (userId is null) return Results.Unauthorized();
@@ -77,6 +80,70 @@ public static class BillingEndpoints
         })
         .WithName("CancelSubscription")
         .RequireAuthorization();
+
+        group.MapPost("/credits-checkout", async (BuyCreditsRequest request, AppSubscriptionService subscriptionService, ClaimsPrincipal user) =>
+        {
+            var userId = GetUserId(user);
+            if (userId is null) return Results.Unauthorized();
+
+            var result = await subscriptionService.BuyCreditsCheckoutAsync(userId.Value, request);
+            return result.IsSuccess
+                ? Results.Ok(result.Value)
+                : Results.BadRequest(new { error = result.Error });
+        })
+        .WithName("BuyCreditsCheckout")
+        .RequireAuthorization();
+
+        group.MapPost("/webhook", async (HttpRequest request, AppSubscriptionService subscriptionService, IConfiguration config) =>
+        {
+            string json;
+            using (var reader = new StreamReader(request.Body))
+                json = await reader.ReadToEndAsync();
+
+            Event stripeEvent;
+            var webhookSecret = config["Stripe:WebhookSecret"];
+            try
+            {
+                if (!string.IsNullOrEmpty(webhookSecret))
+                {
+                    var signature = request.Headers["Stripe-Signature"].ToString();
+                    stripeEvent = EventUtility.ConstructEvent(json, signature, webhookSecret);
+                }
+                else
+                {
+                    stripeEvent = EventUtility.ParseEvent(json);
+                }
+            }
+            catch
+            {
+                return Results.BadRequest();
+            }
+
+            if (stripeEvent.Type == EventTypes.CheckoutSessionCompleted)
+            {
+                var session = stripeEvent.Data.Object as Stripe.Checkout.Session;
+                if (session?.Metadata?.TryGetValue("userId", out var userIdStr) == true
+                    && Guid.TryParse(userIdStr, out var userId))
+                {
+                    session.Metadata.TryGetValue("type", out var type);
+
+                    if (type == "subscription" && session.SubscriptionId is not null)
+                    {
+                        await subscriptionService.ActivateSubscriptionAsync(userId, SubscriptionTier.Pro, session.SubscriptionId);
+                    }
+                    else if (type == "credits"
+                        && session.Metadata.TryGetValue("credits", out var creditsStr)
+                        && int.TryParse(creditsStr, out var credits))
+                    {
+                        await subscriptionService.GrantCreditsAsync(userId, credits);
+                    }
+                }
+            }
+
+            return Results.Ok();
+        })
+        .WithName("StripeWebhook")
+        .AllowAnonymous();
     }
 
     private static Guid? GetUserId(ClaimsPrincipal user)

--- a/backend/src/CarCheck.API/appsettings.json
+++ b/backend/src/CarCheck.API/appsettings.json
@@ -30,5 +30,9 @@
   },
   "Resend": {
     "ApiKey": ""
+  },
+  "Stripe": {
+    "SecretKey": "",
+    "WebhookSecret": ""
   }
 }

--- a/backend/src/CarCheck.Application/Billing/SubscriptionService.cs
+++ b/backend/src/CarCheck.Application/Billing/SubscriptionService.cs
@@ -99,6 +99,39 @@ public class SubscriptionService
         return Result<CreditsBalanceResponse>.Success(new CreditsBalanceResponse(user.Credits, hasMonthly));
     }
 
+    public async Task<Result<CheckoutResponse>> BuyCreditsCheckoutAsync(
+        Guid userId, BuyCreditsRequest request, CancellationToken cancellationToken = default)
+    {
+        var pack = TierConfiguration.CreditPacks.FirstOrDefault(p => p.Credits == request.PackSize);
+        if (pack is null)
+            return Result<CheckoutResponse>.Failure($"Invalid pack size. Choose from: {string.Join(", ", TierConfiguration.CreditPacks.Select(p => p.Credits))}.");
+
+        var user = await _userRepository.GetByIdAsync(userId, cancellationToken);
+        if (user is null)
+            return Result<CheckoutResponse>.Failure("User not found.");
+
+        var checkout = await _billingProvider.CreateCreditsCheckoutSessionAsync(userId, pack.Credits, pack.PriceSek, cancellationToken);
+
+        await _securityEventLogger.LogAsync(userId, "CreditsCheckoutCreated", null, cancellationToken);
+
+        return Result<CheckoutResponse>.Success(new CheckoutResponse(checkout.SessionId, checkout.CheckoutUrl));
+    }
+
+    public async Task<Result<bool>> GrantCreditsAsync(
+        Guid userId, int credits, CancellationToken cancellationToken = default)
+    {
+        var user = await _userRepository.GetByIdAsync(userId, cancellationToken);
+        if (user is null)
+            return Result<bool>.Failure("User not found.");
+
+        user.AddCredits(credits);
+        await _userRepository.UpdateAsync(user, cancellationToken);
+
+        await _securityEventLogger.LogAsync(userId, "CreditsGranted", null, cancellationToken);
+
+        return Result<bool>.Success(true);
+    }
+
     public async Task<Result<SubscriptionResponse>> ActivateSubscriptionAsync(
         Guid userId, SubscriptionTier tier, string externalSubscriptionId, CancellationToken cancellationToken = default)
     {

--- a/backend/src/CarCheck.Application/Interfaces/IBillingProvider.cs
+++ b/backend/src/CarCheck.Application/Interfaces/IBillingProvider.cs
@@ -5,6 +5,7 @@ namespace CarCheck.Application.Interfaces;
 public interface IBillingProvider
 {
     Task<CreateCheckoutResult> CreateCheckoutSessionAsync(Guid userId, SubscriptionTier tier, CancellationToken cancellationToken = default);
+    Task<CreateCheckoutResult> CreateCreditsCheckoutSessionAsync(Guid userId, int credits, decimal priceSek, CancellationToken cancellationToken = default);
     Task<bool> CancelSubscriptionAsync(string externalSubscriptionId, CancellationToken cancellationToken = default);
     Task<SubscriptionStatus?> GetSubscriptionStatusAsync(string externalSubscriptionId, CancellationToken cancellationToken = default);
 }

--- a/backend/src/CarCheck.Infrastructure/CarCheck.Infrastructure.csproj
+++ b/backend/src/CarCheck.Infrastructure/CarCheck.Infrastructure.csproj
@@ -7,10 +7,12 @@
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.*" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.*" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.*" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.15.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.*" />
+    <PackageReference Include="Stripe.net" Version="50.4.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
   </ItemGroup>
 

--- a/backend/src/CarCheck.Infrastructure/DependencyInjection.cs
+++ b/backend/src/CarCheck.Infrastructure/DependencyInjection.cs
@@ -65,7 +65,11 @@ public static class DependencyInjection
 
         // Billing & Subscriptions
         services.AddScoped<ISubscriptionRepository, SubscriptionRepository>();
-        services.AddScoped<IBillingProvider, MockBillingProvider>();
+        var stripeKey = configuration["Stripe:SecretKey"];
+        services.AddScoped<IBillingProvider>(sp =>
+            string.IsNullOrEmpty(stripeKey)
+                ? new MockBillingProvider()
+                : new StripeBillingProvider(configuration));
         services.AddScoped<SubscriptionService>();
 
         // GDPR

--- a/backend/src/CarCheck.Infrastructure/External/MockBillingProvider.cs
+++ b/backend/src/CarCheck.Infrastructure/External/MockBillingProvider.cs
@@ -13,7 +13,14 @@ public class MockBillingProvider : IBillingProvider
     {
         var sessionId = $"mock_session_{Guid.NewGuid():N}";
         var checkoutUrl = $"https://mock-billing.local/checkout/{sessionId}";
+        return Task.FromResult(new CreateCheckoutResult(sessionId, checkoutUrl));
+    }
 
+    public Task<CreateCheckoutResult> CreateCreditsCheckoutSessionAsync(
+        Guid userId, int credits, decimal priceSek, CancellationToken cancellationToken = default)
+    {
+        var sessionId = $"mock_credits_{Guid.NewGuid():N}";
+        var checkoutUrl = $"https://mock-billing.local/credits/{sessionId}";
         return Task.FromResult(new CreateCheckoutResult(sessionId, checkoutUrl));
     }
 

--- a/backend/src/CarCheck.Infrastructure/External/ResendEmailService.cs
+++ b/backend/src/CarCheck.Infrastructure/External/ResendEmailService.cs
@@ -21,7 +21,6 @@ public class ResendEmailService : IEmailService
     public async Task SendPasswordResetAsync(string toEmail, string resetToken, CancellationToken cancellationToken = default)
     {
         var resetUrl = $"{_frontendBaseUrl}/reset-password?token={resetToken}";
-    {
         var payload = new
         {
             from = "CarCheck <onboarding@resend.dev>",

--- a/backend/src/CarCheck.Infrastructure/External/StripeBillingProvider.cs
+++ b/backend/src/CarCheck.Infrastructure/External/StripeBillingProvider.cs
@@ -1,0 +1,121 @@
+using CarCheck.Application.Interfaces;
+using CarCheck.Domain.Enums;
+using Microsoft.Extensions.Configuration;
+using Stripe;
+using Stripe.Checkout;
+using StripeSubService = Stripe.SubscriptionService;
+
+namespace CarCheck.Infrastructure.External;
+
+public class StripeBillingProvider : IBillingProvider
+{
+    private readonly StripeClient _client;
+    private readonly string _frontendBaseUrl;
+
+    public StripeBillingProvider(IConfiguration configuration)
+    {
+        var secretKey = configuration["Stripe:SecretKey"]
+            ?? throw new InvalidOperationException("Stripe:SecretKey is not configured.");
+        _client = new StripeClient(secretKey);
+        _frontendBaseUrl = configuration["Frontend:BaseUrl"] ?? "http://localhost:5173";
+    }
+
+    public async Task<CreateCheckoutResult> CreateCheckoutSessionAsync(
+        Guid userId, SubscriptionTier tier, CancellationToken cancellationToken = default)
+    {
+        var service = new SessionService(_client);
+        var options = new SessionCreateOptions
+        {
+            Mode = "subscription",
+            LineItems =
+            [
+                new SessionLineItemOptions
+                {
+                    PriceData = new SessionLineItemPriceDataOptions
+                    {
+                        UnitAmount = 49900, // 499 SEK in öre
+                        Currency = "sek",
+                        Recurring = new SessionLineItemPriceDataRecurringOptions { Interval = "month" },
+                        ProductData = new SessionLineItemPriceDataProductDataOptions
+                        {
+                            Name = "CarCheck Månadsplan",
+                            Description = "Obegränsade bilsökningar per månad"
+                        }
+                    },
+                    Quantity = 1
+                }
+            ],
+            Metadata = new Dictionary<string, string>
+            {
+                ["userId"] = userId.ToString(),
+                ["type"] = "subscription"
+            },
+            SuccessUrl = $"{_frontendBaseUrl}/billing?success=true",
+            CancelUrl = $"{_frontendBaseUrl}/billing?canceled=true"
+        };
+
+        var session = await service.CreateAsync(options, cancellationToken: cancellationToken);
+        return new CreateCheckoutResult(session.Id, session.Url);
+    }
+
+    public async Task<CreateCheckoutResult> CreateCreditsCheckoutSessionAsync(
+        Guid userId, int credits, decimal priceSek, CancellationToken cancellationToken = default)
+    {
+        var unitAmount = (long)(priceSek * 100); // SEK → öre
+        var service = new SessionService(_client);
+        var options = new SessionCreateOptions
+        {
+            Mode = "payment",
+            LineItems =
+            [
+                new SessionLineItemOptions
+                {
+                    PriceData = new SessionLineItemPriceDataOptions
+                    {
+                        UnitAmount = unitAmount,
+                        Currency = "sek",
+                        ProductData = new SessionLineItemPriceDataProductDataOptions
+                        {
+                            Name = $"CarCheck — {credits} {(credits == 1 ? "sökning" : "sökningar")}",
+                            Description = "Engångsköp av bilsökningar"
+                        }
+                    },
+                    Quantity = 1
+                }
+            ],
+            Metadata = new Dictionary<string, string>
+            {
+                ["userId"] = userId.ToString(),
+                ["type"] = "credits",
+                ["credits"] = credits.ToString()
+            },
+            SuccessUrl = $"{_frontendBaseUrl}/billing?success=true&credits={credits}",
+            CancelUrl = $"{_frontendBaseUrl}/billing?canceled=true"
+        };
+
+        var session = await service.CreateAsync(options, cancellationToken: cancellationToken);
+        return new CreateCheckoutResult(session.Id, session.Url);
+    }
+
+    public async Task<bool> CancelSubscriptionAsync(
+        string externalSubscriptionId, CancellationToken cancellationToken = default)
+    {
+        var service = new StripeSubService(_client);
+        await service.UpdateAsync(externalSubscriptionId,
+            new SubscriptionUpdateOptions { CancelAtPeriodEnd = true },
+            cancellationToken: cancellationToken);
+        return true;
+    }
+
+    public async Task<SubscriptionStatus?> GetSubscriptionStatusAsync(
+        string externalSubscriptionId, CancellationToken cancellationToken = default)
+    {
+        var service = new StripeSubService(_client);
+        var subscription = await service.GetAsync(externalSubscriptionId, cancellationToken: cancellationToken);
+        if (subscription is null) return null;
+        return new Application.Interfaces.SubscriptionStatus(
+            subscription.Id,
+            subscription.Status == "active",
+            null);
+    }
+}

--- a/frontend/src/api/billing.api.ts
+++ b/frontend/src/api/billing.api.ts
@@ -25,6 +25,9 @@ export const billingApi = {
   buyCredits: (data: BuyCreditsRequest) =>
     apiClient.post<CreditsBalanceResponse>('/billing/buy-credits', data),
 
+  creditsCheckout: (data: BuyCreditsRequest) =>
+    apiClient.post<CheckoutResponse>('/billing/credits-checkout', data),
+
   cancelSubscription: () =>
     apiClient.post('/billing/cancel'),
 }

--- a/frontend/src/features/billing/billing-page.tsx
+++ b/frontend/src/features/billing/billing-page.tsx
@@ -1,8 +1,10 @@
+import { useEffect } from 'react'
+import { useSearchParams } from 'react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Check, Zap, Infinity, CreditCard, Calendar } from 'lucide-react'
-import { useSubscription, useCreateCheckout, useCancelSubscription, useBuyCredits, useCreditPackages } from '@/hooks/use-billing'
+import { useSubscription, useCreateCheckout, useCancelSubscription, useCreditsCheckout, useCreditPackages } from '@/hooks/use-billing'
 import { LoadingSpinner } from '@/components/common/loading-spinner'
 import { ErrorDisplay } from '@/components/common/error-display'
 import { formatDate } from '@/lib/format'
@@ -21,11 +23,27 @@ function formatSek(amount: number) {
 }
 
 export function BillingPage() {
+  const [searchParams, setSearchParams] = useSearchParams()
   const { data: sub, isLoading: subLoading, error: subError } = useSubscription()
   const { data: packs, isLoading: packsLoading } = useCreditPackages()
   const checkoutMutation = useCreateCheckout()
-  const buyMutation = useBuyCredits()
+  const creditsCheckoutMutation = useCreditsCheckout()
   const cancelMutation = useCancelSubscription()
+
+  useEffect(() => {
+    if (searchParams.get('success') === 'true') {
+      const credits = searchParams.get('credits')
+      if (credits) {
+        toast.success(`${credits} ${Number(credits) === 1 ? 'sökning' : 'sökningar'} tillagda på ditt konto!`)
+      } else {
+        toast.success('Månadsplanen är nu aktiv — obegränsade sökningar!')
+      }
+      setSearchParams({}, { replace: true })
+    } else if (searchParams.get('canceled') === 'true') {
+      toast.info('Betalningen avbröts.')
+      setSearchParams({}, { replace: true })
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (subLoading || packsLoading) return <LoadingSpinner />
   if (subError) return <ErrorDisplay error={subError} />
@@ -46,13 +64,13 @@ export function BillingPage() {
   }
 
   const handleBuyCredits = (packSize: number) => {
-    buyMutation.mutate(packSize, {
+    creditsCheckoutMutation.mutate(packSize, {
       onSuccess: (data) => {
-        toast.success(`${packSize} ${packSize === 1 ? 'sökning' : 'sökningar'} tillagda! Saldo: ${data.credits}`)
+        window.location.href = data.checkoutUrl
       },
       onError: (err) => {
         const msg = (err as { response?: { data?: { error?: string } } }).response?.data?.error
-        toast.error(msg || 'Köpet misslyckades')
+        toast.error(msg || 'Kunde inte starta betalning')
       },
     })
   }
@@ -166,7 +184,7 @@ export function BillingPage() {
                     className={cn('w-full', pack.isBestValue ? 'bg-blue-600 hover:bg-blue-500' : '')}
                     variant={pack.isBestValue ? 'default' : 'outline'}
                     onClick={() => handleBuyCredits(pack.credits)}
-                    disabled={buyMutation.isPending}
+                    disabled={creditsCheckoutMutation.isPending}
                   >
                     Köp nu
                   </Button>

--- a/frontend/src/hooks/use-billing.ts
+++ b/frontend/src/hooks/use-billing.ts
@@ -41,6 +41,12 @@ export function useBuyCredits() {
   })
 }
 
+export function useCreditsCheckout() {
+  return useMutation({
+    mutationFn: (packSize: number) => billingApi.creditsCheckout({ packSize }).then((r) => r.data),
+  })
+}
+
 export function useCancelSubscription() {
   const queryClient = useQueryClient()
   return useMutation({


### PR DESCRIPTION
## Summary
- **StripeBillingProvider**: fullständig Stripe Checkout-integration för månadsplan (subscription) och kreditpaket (payment)
- **Webhook** `POST /api/billing/webhook`: lyssnar på `checkout.session.completed`, aktiverar subscription eller lägger till credits baserat på metadata
- **Credits-checkout** `POST /api/billing/credits-checkout`: ny endpoint som skapar Stripe-session för engångsköp
- **Frontend**: kreditköp redirectar till Stripe Checkout istället för direkt köp; `?success=true` / `?canceled=true` hanteras med toast
- **Fallback**: om `Stripe:SecretKey` är tom används `MockBillingProvider` — dev utan Stripe fungerar fortfarande

## Flöde
1. Användare klickar "Köp nu" → backend skapar Stripe Checkout-session → redirect till Stripe
2. Användare betalar med testkort `4242 4242 4242 4242`
3. Stripe skickar webhook → backend lägger till credits / aktiverar plan
4. Stripe redirectar tillbaka till `/billing?success=true` → toast visas

## Webhook-setup (kräver manuell konfiguration)
Stripe webhook secret behöver läggas till i `appsettings.Development.json` under `Stripe:WebhookSecret`.
Lokalt: använd Stripe CLI: `stripe listen --forward-to localhost:5171/api/billing/webhook`

## Test plan
- [ ] Klicka "Köp nu" på ett kreditpaket → Stripe Checkout öppnas
- [ ] Betala med `4242 4242 4242 4242`, exp `12/34`, CVC `123`
- [ ] Tillbaka på `/billing?success=true` → toast visas, credits ökar
- [ ] Klicka "Teckna månadsplan" → Stripe Checkout (subscription)
- [ ] Avbryt → `/billing?canceled=true` → toast "avbröts"

🤖 Generated with [Claude Code](https://claude.com/claude-code)