### PR TITLE
feat: e-postverifiering, köphistorik och svenska felmeddelanden

### DIFF
--- a/backend/src/CarCheck.API/Endpoints/AuthEndpoints.cs
+++ b/backend/src/CarCheck.API/Endpoints/AuthEndpoints.cs
@@ -47,7 +47,7 @@ public static class AuthEndpoints
 
             var result = await authService.LogoutAsync(userId.Value, request.RefreshToken);
             return result.IsSuccess
-                ? Results.Ok(new { message = "Logged out successfully." })
+                ? Results.Ok(new { message = "Du har loggats ut." })
                 : Results.BadRequest(new { error = result.Error });
         })
         .WithName("Logout")
@@ -60,7 +60,7 @@ public static class AuthEndpoints
 
             var result = await authService.LogoutAllAsync(userId.Value);
             return result.IsSuccess
-                ? Results.Ok(new { message = "All sessions invalidated." })
+                ? Results.Ok(new { message = "Alla sessioner har avslutats." })
                 : Results.BadRequest(new { error = result.Error });
         })
         .WithName("LogoutAll")
@@ -73,7 +73,7 @@ public static class AuthEndpoints
 
             var result = await authService.ChangePasswordAsync(userId.Value, request);
             return result.IsSuccess
-                ? Results.Ok(new { message = "Password changed successfully." })
+                ? Results.Ok(new { message = "Lösenordet har ändrats." })
                 : Results.BadRequest(new { error = result.Error });
         })
         .WithName("ChangePassword")
@@ -95,6 +95,16 @@ public static class AuthEndpoints
                 : Results.BadRequest(new { error = result.Error });
         })
         .WithName("ResetPassword")
+        .AllowAnonymous();
+
+        group.MapGet("/verify-email", async (string token, AuthService authService) =>
+        {
+            var result = await authService.VerifyEmailAsync(token);
+            return result.IsSuccess
+                ? Results.Ok(new { message = "E-postadressen är verifierad. Du har fått 1 gratis sökning!" })
+                : Results.BadRequest(new { error = result.Error });
+        })
+        .WithName("VerifyEmail")
         .AllowAnonymous();
     }
 

--- a/backend/src/CarCheck.API/Endpoints/BillingEndpoints.cs
+++ b/backend/src/CarCheck.API/Endpoints/BillingEndpoints.cs
@@ -75,10 +75,23 @@ public static class BillingEndpoints
 
             var result = await subscriptionService.CancelSubscriptionAsync(userId.Value);
             return result.IsSuccess
-                ? Results.Ok(new { message = "Subscription cancelled." })
+                ? Results.Ok(new { message = "Abonnemanget har avslutats." })
                 : Results.BadRequest(new { error = result.Error });
         })
         .WithName("CancelSubscription")
+        .RequireAuthorization();
+
+        group.MapGet("/transactions", async (AppSubscriptionService subscriptionService, ClaimsPrincipal user) =>
+        {
+            var userId = GetUserId(user);
+            if (userId is null) return Results.Unauthorized();
+
+            var result = await subscriptionService.GetTransactionsAsync(userId.Value);
+            return result.IsSuccess
+                ? Results.Ok(result.Value)
+                : Results.BadRequest(new { error = result.Error });
+        })
+        .WithName("GetTransactions")
         .RequireAuthorization();
 
         group.MapPost("/credits-checkout", async (BuyCreditsRequest request, AppSubscriptionService subscriptionService, ClaimsPrincipal user) =>
@@ -126,16 +139,20 @@ public static class BillingEndpoints
                     && Guid.TryParse(userIdStr, out var userId))
                 {
                     session.Metadata.TryGetValue("type", out var type);
+                    var paymentId = session.Id; // Stripe session ID as idempotency key
 
                     if (type == "subscription" && session.SubscriptionId is not null)
                     {
-                        await subscriptionService.ActivateSubscriptionAsync(userId, SubscriptionTier.Pro, session.SubscriptionId);
+                        await subscriptionService.ActivateSubscriptionAsync(
+                            userId, SubscriptionTier.Pro, session.SubscriptionId,
+                            externalPaymentId: paymentId);
                     }
                     else if (type == "credits"
                         && session.Metadata.TryGetValue("credits", out var creditsStr)
                         && int.TryParse(creditsStr, out var credits))
                     {
-                        await subscriptionService.GrantCreditsAsync(userId, credits);
+                        await subscriptionService.GrantCreditsAsync(
+                            userId, credits, externalPaymentId: paymentId);
                     }
                 }
             }

--- a/backend/src/CarCheck.API/Endpoints/CarEndpoints.cs
+++ b/backend/src/CarCheck.API/Endpoints/CarEndpoints.cs
@@ -20,7 +20,7 @@ public static class CarEndpoints
             {
                 var captchaValid = await captchaService.ValidateAsync(request.CaptchaToken);
                 if (!captchaValid)
-                    return Results.BadRequest(new { error = "CAPTCHA validation failed." });
+                    return Results.BadRequest(new { error = "CAPTCHA-validering misslyckades." });
             }
 
             var result = await carSearchService.SearchByRegistrationAsync(userId.Value, request);

--- a/backend/src/CarCheck.API/Endpoints/FavoriteEndpoints.cs
+++ b/backend/src/CarCheck.API/Endpoints/FavoriteEndpoints.cs
@@ -51,7 +51,7 @@ public static class FavoriteEndpoints
 
             var result = await favoriteService.RemoveFavoriteAsync(userId.Value, carId);
             return result.IsSuccess
-                ? Results.Ok(new { message = "Favorite removed." })
+                ? Results.Ok(new { message = "Favoriten har tagits bort." })
                 : Results.NotFound(new { error = result.Error });
         })
         .WithName("RemoveFavorite");

--- a/backend/src/CarCheck.API/Endpoints/HistoryEndpoints.cs
+++ b/backend/src/CarCheck.API/Endpoints/HistoryEndpoints.cs
@@ -28,7 +28,7 @@ public static class HistoryEndpoints
 
             var result = await historyService.DeleteEntryAsync(userId.Value, id);
             return result.IsSuccess
-                ? Results.Ok(new { message = "Entry deleted." })
+                ? Results.Ok(new { message = "Historikposten har tagits bort." })
                 : Results.NotFound(new { error = result.Error });
         })
         .WithName("DeleteHistoryEntry");
@@ -39,7 +39,7 @@ public static class HistoryEndpoints
             if (userId is null) return Results.Unauthorized();
 
             var result = await historyService.ClearHistoryAsync(userId.Value);
-            return Results.Ok(new { message = "History cleared." });
+            return Results.Ok(new { message = "Historiken har rensats." });
         })
         .WithName("ClearHistory");
     }

--- a/backend/src/CarCheck.API/Middleware/DailyQuotaMiddleware.cs
+++ b/backend/src/CarCheck.API/Middleware/DailyQuotaMiddleware.cs
@@ -18,7 +18,6 @@ public class DailyQuotaMiddleware
 
     public async Task InvokeAsync(
         HttpContext context,
-        ISearchHistoryRepository searchHistoryRepository,
         ISubscriptionRepository subscriptionRepository,
         IUserRepository userRepository)
     {
@@ -43,7 +42,6 @@ public class DailyQuotaMiddleware
 
         if (hasMonthly)
         {
-            // Unlimited monthly plan
             context.Response.Headers["X-DailyQuota-Limit"] = "unlimited";
             context.Response.Headers["X-DailyQuota-Remaining"] = "unlimited";
             context.Response.Headers["X-Subscription-Tier"] = subscription!.Tier.ToString();
@@ -53,16 +51,26 @@ public class DailyQuotaMiddleware
 
         var user = await userRepository.GetByIdAsync(userId);
 
+        // Block unverified users
+        if (user is not null && !user.EmailVerified)
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsJsonAsync(new
+            {
+                error = "Du måste verifiera din e-postadress innan du kan söka. Kolla din inkorg.",
+                requiresEmailVerification = true
+            });
+            return;
+        }
+
         if (user is not null && user.Credits > 0)
         {
-            // Credit-based access
             context.Response.Headers["X-DailyQuota-Limit"] = "credits";
             context.Response.Headers["X-DailyQuota-Remaining"] = user.Credits.ToString();
             context.Response.Headers["X-Subscription-Tier"] = SubscriptionTier.Free.ToString();
 
             await _next(context);
 
-            // Deduct 1 credit after a successful search
             if (context.Response.StatusCode is >= 200 and < 300)
             {
                 user.ConsumeCredit();
@@ -71,28 +79,12 @@ public class DailyQuotaMiddleware
             return;
         }
 
-        // Free tier: limited daily searches
-        var todayCount = await searchHistoryRepository.GetCountByUserIdTodayAsync(userId);
-        var freeLimit = TierConfiguration.FreeDaily;
-
-        context.Response.Headers["X-DailyQuota-Limit"] = freeLimit.ToString();
-        context.Response.Headers["X-DailyQuota-Remaining"] = Math.Max(0, freeLimit - todayCount).ToString();
-        context.Response.Headers["X-Subscription-Tier"] = SubscriptionTier.Free.ToString();
-
-        if (todayCount >= freeLimit)
+        // No credits, no subscription → blocked
+        context.Response.StatusCode = StatusCodes.Status402PaymentRequired;
+        await context.Response.WriteAsJsonAsync(new
         {
-            context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
-            await context.Response.WriteAsJsonAsync(new
-            {
-                error = "Du har använt dina gratis sökningar för idag. Köp sökningar eller teckna ett abonnemang.",
-                tier = SubscriptionTier.Free.ToString(),
-                limit = freeLimit,
-                used = todayCount,
-                resetsAt = DateTime.UtcNow.Date.AddDays(1).ToString("o")
-            });
-            return;
-        }
-
-        await _next(context);
+            error = "Du har inga sökningar kvar. Köp sökningar eller teckna ett abonnemang.",
+            tier = SubscriptionTier.Free.ToString()
+        });
     }
 }

--- a/backend/src/CarCheck.API/Middleware/RateLimitingMiddleware.cs
+++ b/backend/src/CarCheck.API/Middleware/RateLimitingMiddleware.cs
@@ -27,7 +27,7 @@ public class RateLimitingMiddleware
         {
             context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
             context.Response.Headers["Retry-After"] = ((int)(result.ResetsAt - DateTime.UtcNow).TotalSeconds).ToString();
-            await context.Response.WriteAsJsonAsync(new { error = "Too many requests. Please try again later." });
+            await context.Response.WriteAsJsonAsync(new { error = "För många förfrågningar. Försök igen om en stund." });
             return;
         }
 

--- a/backend/src/CarCheck.Application/Auth/AuthService.cs
+++ b/backend/src/CarCheck.Application/Auth/AuthService.cs
@@ -14,6 +14,8 @@ public class AuthService
     private readonly IRefreshTokenRepository _refreshTokenRepository;
     private readonly ISecurityEventLogger _securityEventLogger;
     private readonly IPasswordResetRepository _passwordResetRepository;
+    private readonly IEmailVerificationRepository _emailVerificationRepository;
+    private readonly ICreditTransactionRepository _transactionRepository;
     private readonly IEmailService _emailService;
 
     public AuthService(
@@ -23,6 +25,8 @@ public class AuthService
         IRefreshTokenRepository refreshTokenRepository,
         ISecurityEventLogger securityEventLogger,
         IPasswordResetRepository passwordResetRepository,
+        IEmailVerificationRepository emailVerificationRepository,
+        ICreditTransactionRepository transactionRepository,
         IEmailService emailService)
     {
         _userRepository = userRepository;
@@ -31,6 +35,8 @@ public class AuthService
         _refreshTokenRepository = refreshTokenRepository;
         _securityEventLogger = securityEventLogger;
         _passwordResetRepository = passwordResetRepository;
+        _emailVerificationRepository = emailVerificationRepository;
+        _transactionRepository = transactionRepository;
         _emailService = emailService;
     }
 
@@ -39,10 +45,10 @@ public class AuthService
         var email = Email.Create(request.Email);
 
         if (await _userRepository.ExistsByEmailAsync(email, cancellationToken))
-            return Result<UserResponse>.Failure("Email is already registered.");
+            return Result<UserResponse>.Failure("E-postadressen är redan registrerad.");
 
         if (request.Password.Length < 8)
-            return Result<UserResponse>.Failure("Password must be at least 8 characters.");
+            return Result<UserResponse>.Failure("Lösenordet måste vara minst 8 tecken.");
 
         var hash = _passwordHasher.Hash(request.Password);
         var user = User.Create(request.Email, hash);
@@ -50,7 +56,45 @@ public class AuthService
         await _userRepository.AddAsync(user, cancellationToken);
         await _securityEventLogger.LogAsync(user.Id, "Registered", null, cancellationToken);
 
+        // Send verification email
+        var verification = EmailVerification.Create(user.Id, TimeSpan.FromHours(24));
+        await _emailVerificationRepository.AddAsync(verification, cancellationToken);
+        await _emailService.SendEmailVerificationAsync(email.Value, verification.Token, cancellationToken);
+
         return Result<UserResponse>.Success(new UserResponse(user.Id, user.Email.Value, user.EmailVerified, user.TwoFactorEnabled));
+    }
+
+    public async Task<Result<bool>> VerifyEmailAsync(string token, CancellationToken cancellationToken = default)
+    {
+        var verification = await _emailVerificationRepository.GetByTokenAsync(token, cancellationToken);
+
+        if (verification is null || verification.IsExpired() || verification.Used)
+            return Result<bool>.Failure("Ogiltig eller utgången verifieringslänk.");
+
+        var user = await _userRepository.GetByIdAsync(verification.UserId, cancellationToken);
+        if (user is null)
+            return Result<bool>.Failure("Användare hittades inte.");
+
+        if (user.EmailVerified)
+        {
+            verification.MarkUsed();
+            await _emailVerificationRepository.UpdateAsync(verification, cancellationToken);
+            return Result<bool>.Success(true);
+        }
+
+        user.VerifyEmail();
+        user.AddCredits(1);
+        await _userRepository.UpdateAsync(user, cancellationToken);
+
+        await _transactionRepository.AddAsync(
+            CreditTransaction.CreateTrial(user.Id), cancellationToken);
+
+        verification.MarkUsed();
+        await _emailVerificationRepository.UpdateAsync(verification, cancellationToken);
+
+        await _securityEventLogger.LogAsync(user.Id, "EmailVerified", null, cancellationToken);
+
+        return Result<bool>.Success(true);
     }
 
     public async Task<Result<AuthResponse>> LoginAsync(LoginRequest request, CancellationToken cancellationToken = default)
@@ -63,7 +107,7 @@ public class AuthService
             if (user is not null)
                 await _securityEventLogger.LogAsync(user.Id, "LoginFailed", null, cancellationToken);
 
-            return Result<AuthResponse>.Failure("Invalid email or password.");
+            return Result<AuthResponse>.Failure("Felaktig e-postadress eller lösenord.");
         }
 
         var accessToken = _tokenService.GenerateAccessToken(user);
@@ -89,11 +133,11 @@ public class AuthService
         var existing = await _refreshTokenRepository.GetByTokenAsync(request.RefreshToken, cancellationToken);
 
         if (existing is null || existing.Revoked || existing.ExpiresAt < DateTime.UtcNow)
-            return Result<AuthResponse>.Failure("Invalid or expired refresh token.");
+            return Result<AuthResponse>.Failure("Ogiltig eller utgången session. Logga in igen.");
 
         var user = await _userRepository.GetByIdAsync(existing.UserId, cancellationToken);
         if (user is null)
-            return Result<AuthResponse>.Failure("User not found.");
+            return Result<AuthResponse>.Failure("Användare hittades inte.");
 
         // Rotate: revoke old, issue new
         await _refreshTokenRepository.RevokeAsync(existing.Token, cancellationToken);
@@ -179,13 +223,13 @@ public class AuthService
     {
         var user = await _userRepository.GetByIdAsync(userId, cancellationToken);
         if (user is null)
-            return Result<bool>.Failure("User not found.");
+            return Result<bool>.Failure("Användare hittades inte.");
 
         if (!_passwordHasher.Verify(request.CurrentPassword, user.PasswordHash))
-            return Result<bool>.Failure("Current password is incorrect.");
+            return Result<bool>.Failure("Nuvarande lösenord är felaktigt.");
 
         if (request.NewPassword.Length < 8)
-            return Result<bool>.Failure("New password must be at least 8 characters.");
+            return Result<bool>.Failure("Lösenordet måste vara minst 8 tecken.");
 
         user.ChangePassword(_passwordHasher.Hash(request.NewPassword));
         await _userRepository.UpdateAsync(user, cancellationToken);

--- a/backend/src/CarCheck.Application/Billing/DTOs/BillingDTOs.cs
+++ b/backend/src/CarCheck.Application/Billing/DTOs/BillingDTOs.cs
@@ -43,3 +43,11 @@ public record CreditPackResponse(
 public record CreditsBalanceResponse(
     int Credits,
     bool HasMonthlySubscription);
+
+public record TransactionResponse(
+    Guid Id,
+    string Type,
+    int? Credits,
+    decimal AmountSek,
+    string Description,
+    DateTime CreatedAt);

--- a/backend/src/CarCheck.Application/Billing/SubscriptionService.cs
+++ b/backend/src/CarCheck.Application/Billing/SubscriptionService.cs
@@ -13,17 +13,20 @@ public class SubscriptionService
     private readonly IUserRepository _userRepository;
     private readonly IBillingProvider _billingProvider;
     private readonly ISecurityEventLogger _securityEventLogger;
+    private readonly ICreditTransactionRepository _transactionRepository;
 
     public SubscriptionService(
         ISubscriptionRepository subscriptionRepository,
         IUserRepository userRepository,
         IBillingProvider billingProvider,
-        ISecurityEventLogger securityEventLogger)
+        ISecurityEventLogger securityEventLogger,
+        ICreditTransactionRepository transactionRepository)
     {
         _subscriptionRepository = subscriptionRepository;
         _userRepository = userRepository;
         _billingProvider = billingProvider;
         _securityEventLogger = securityEventLogger;
+        _transactionRepository = transactionRepository;
     }
 
     public async Task<Result<SubscriptionResponse>> GetCurrentSubscriptionAsync(
@@ -64,11 +67,11 @@ public class SubscriptionService
         Guid userId, SubscribeRequest request, CancellationToken cancellationToken = default)
     {
         if (request.Tier == SubscriptionTier.Free)
-            return Result<CheckoutResponse>.Failure("Cannot purchase a free subscription.");
+            return Result<CheckoutResponse>.Failure("Det går inte att köpa ett gratisabonnemang.");
 
         var user = await _userRepository.GetByIdAsync(userId, cancellationToken);
         if (user is null)
-            return Result<CheckoutResponse>.Failure("User not found.");
+            return Result<CheckoutResponse>.Failure("Användare hittades inte.");
 
         var checkout = await _billingProvider.CreateCheckoutSessionAsync(userId, request.Tier, cancellationToken);
 
@@ -82,11 +85,11 @@ public class SubscriptionService
     {
         var validPacks = TierConfiguration.CreditPacks.Select(p => p.Credits).ToHashSet();
         if (!validPacks.Contains(request.PackSize))
-            return Result<CreditsBalanceResponse>.Failure($"Invalid pack size. Choose from: {string.Join(", ", validPacks)}.");
+            return Result<CreditsBalanceResponse>.Failure($"Ogiltigt antal sökningar. Välj bland: {string.Join(", ", validPacks)}.");
 
         var user = await _userRepository.GetByIdAsync(userId, cancellationToken);
         if (user is null)
-            return Result<CreditsBalanceResponse>.Failure("User not found.");
+            return Result<CreditsBalanceResponse>.Failure("Användare hittades inte.");
 
         user.AddCredits(request.PackSize);
         await _userRepository.UpdateAsync(user, cancellationToken);
@@ -104,11 +107,11 @@ public class SubscriptionService
     {
         var pack = TierConfiguration.CreditPacks.FirstOrDefault(p => p.Credits == request.PackSize);
         if (pack is null)
-            return Result<CheckoutResponse>.Failure($"Invalid pack size. Choose from: {string.Join(", ", TierConfiguration.CreditPacks.Select(p => p.Credits))}.");
+            return Result<CheckoutResponse>.Failure($"Ogiltigt antal sökningar. Välj bland: {string.Join(", ", TierConfiguration.CreditPacks.Select(p => p.Credits))}.");
 
         var user = await _userRepository.GetByIdAsync(userId, cancellationToken);
         if (user is null)
-            return Result<CheckoutResponse>.Failure("User not found.");
+            return Result<CheckoutResponse>.Failure("Användare hittades inte.");
 
         var checkout = await _billingProvider.CreateCreditsCheckoutSessionAsync(userId, pack.Credits, pack.PriceSek, cancellationToken);
 
@@ -118,14 +121,26 @@ public class SubscriptionService
     }
 
     public async Task<Result<bool>> GrantCreditsAsync(
-        Guid userId, int credits, CancellationToken cancellationToken = default)
+        Guid userId, int credits, CancellationToken cancellationToken = default,
+        string? externalPaymentId = null)
     {
+        // Idempotency: skip if this payment was already processed
+        if (externalPaymentId is not null &&
+            await _transactionRepository.ExistsByExternalPaymentIdAsync(externalPaymentId, cancellationToken))
+            return Result<bool>.Success(true);
+
         var user = await _userRepository.GetByIdAsync(userId, cancellationToken);
         if (user is null)
-            return Result<bool>.Failure("User not found.");
+            return Result<bool>.Failure("Användare hittades inte.");
 
         user.AddCredits(credits);
         await _userRepository.UpdateAsync(user, cancellationToken);
+
+        var pack = TierConfiguration.CreditPacks.FirstOrDefault(p => p.Credits == credits);
+        var amountOre = pack is not null ? (int)(pack.PriceSek * 100) : 0;
+        await _transactionRepository.AddAsync(
+            CreditTransaction.CreateCredits(userId, credits, amountOre, externalPaymentId),
+            cancellationToken);
 
         await _securityEventLogger.LogAsync(userId, "CreditsGranted", null, cancellationToken);
 
@@ -133,8 +148,21 @@ public class SubscriptionService
     }
 
     public async Task<Result<SubscriptionResponse>> ActivateSubscriptionAsync(
-        Guid userId, SubscriptionTier tier, string externalSubscriptionId, CancellationToken cancellationToken = default)
+        Guid userId, SubscriptionTier tier, string externalSubscriptionId, CancellationToken cancellationToken = default,
+        string? externalPaymentId = null)
     {
+        // Idempotency: skip if this payment was already processed
+        if (externalPaymentId is not null &&
+            await _transactionRepository.ExistsByExternalPaymentIdAsync(externalPaymentId, cancellationToken))
+        {
+            var existing2 = await _subscriptionRepository.GetActiveByUserIdAsync(userId, cancellationToken);
+            var user2 = await _userRepository.GetByIdAsync(userId, cancellationToken);
+            var limits2 = TierConfiguration.GetLimits(tier);
+            return Result<SubscriptionResponse>.Success(new SubscriptionResponse(
+                existing2?.Id ?? Guid.Empty, tier, limits2.Name, true,
+                existing2?.StartDate ?? DateTime.UtcNow, null, MapLimits(limits2), user2?.Credits ?? 0));
+        }
+
         var existing = await _subscriptionRepository.GetActiveByUserIdAsync(userId, cancellationToken);
         if (existing is not null)
         {
@@ -144,6 +172,10 @@ public class SubscriptionService
 
         var subscription = Subscription.Create(userId, tier, externalSubscriptionId);
         await _subscriptionRepository.AddAsync(subscription, cancellationToken);
+
+        await _transactionRepository.AddAsync(
+            CreditTransaction.CreateSubscription(userId, 49900, externalPaymentId),
+            cancellationToken);
 
         await _securityEventLogger.LogAsync(userId, "SubscriptionActivated", null, cancellationToken);
 
@@ -165,7 +197,7 @@ public class SubscriptionService
     {
         var subscription = await _subscriptionRepository.GetActiveByUserIdAsync(userId, cancellationToken);
         if (subscription is null)
-            return Result<bool>.Failure("No active subscription found.");
+            return Result<bool>.Failure("Inget aktivt abonnemang hittades.");
 
         if (subscription.ExternalSubscriptionId is not null)
             await _billingProvider.CancelSubscriptionAsync(subscription.ExternalSubscriptionId, cancellationToken);
@@ -203,6 +235,23 @@ public class SubscriptionService
                     limits.PricePerMonthSek);
             })
             .ToList();
+    }
+
+    public async Task<Result<IReadOnlyList<TransactionResponse>>> GetTransactionsAsync(
+        Guid userId, CancellationToken cancellationToken = default)
+    {
+        var transactions = await _transactionRepository.GetByUserIdAsync(userId, cancellationToken);
+        var result = transactions
+            .Select(t => new TransactionResponse(
+                t.Id,
+                t.Type,
+                t.Credits,
+                t.AmountOre / 100m,
+                t.Description,
+                t.CreatedAt))
+            .ToList();
+
+        return Result<IReadOnlyList<TransactionResponse>>.Success(result);
     }
 
     private static TierLimitsResponse MapLimits(TierLimits limits) =>

--- a/backend/src/CarCheck.Application/Cars/CarSearchService.cs
+++ b/backend/src/CarCheck.Application/Cars/CarSearchService.cs
@@ -66,7 +66,7 @@ public class CarSearchService
         // Fetch from external provider
         var externalData = await _carDataProvider.FetchByRegistrationAsync(regNum, cancellationToken);
         if (externalData is null)
-            return Result<CarSearchResponse>.Failure("No vehicle found with this registration number.");
+            return Result<CarSearchResponse>.Failure("Inget fordon hittades med det registreringsnumret.");
 
         // Persist car
         var car = Car.Create(
@@ -101,7 +101,7 @@ public class CarSearchService
     {
         var car = await _carRepository.GetByIdAsync(carId, cancellationToken);
         if (car is null)
-            return Result<CarSearchResponse>.Failure("Car not found.");
+            return Result<CarSearchResponse>.Failure("Bilen hittades inte.");
 
         var externalData = await _carDataProvider.FetchByRegistrationAsync(car.RegistrationNumber.Value, cancellationToken);
         return Result<CarSearchResponse>.Success(MapToResponse(car, externalData));
@@ -119,11 +119,11 @@ public class CarSearchService
         // Fetch car from DB
         var car2 = await _carRepository.GetByIdAsync(carId, cancellationToken);
         if (car2 is null)
-            return Result<CarAnalysisResponse>.Failure("Car not found.");
+            return Result<CarAnalysisResponse>.Failure("Bilen hittades inte.");
 
         var externalData = await _carDataProvider.FetchByRegistrationAsync(car2.RegistrationNumber.Value, cancellationToken);
         if (externalData is null)
-            return Result<CarAnalysisResponse>.Failure("Unable to fetch vehicle data for analysis.");
+            return Result<CarAnalysisResponse>.Failure("Kunde inte hämta fordonsdata för analys.");
 
         // Run analysis
         var (score, recommendation, breakdown) = _analysisEngine.Analyze(externalData);

--- a/backend/src/CarCheck.Application/Favorites/FavoriteService.cs
+++ b/backend/src/CarCheck.Application/Favorites/FavoriteService.cs
@@ -50,10 +50,10 @@ public class FavoriteService
     {
         var car = await _carRepository.GetByIdAsync(request.CarId, cancellationToken);
         if (car is null)
-            return Result<FavoriteResponse>.Failure("Car not found.");
+            return Result<FavoriteResponse>.Failure("Bilen hittades inte.");
 
         if (await _favoriteRepository.ExistsAsync(userId, request.CarId, cancellationToken))
-            return Result<FavoriteResponse>.Failure("Car is already in favorites.");
+            return Result<FavoriteResponse>.Failure("Bilen finns redan i favoriter.");
 
         var favorite = Favorite.Create(userId, request.CarId);
         await _favoriteRepository.AddAsync(favorite, cancellationToken);
@@ -79,7 +79,7 @@ public class FavoriteService
         Guid userId, Guid carId, CancellationToken cancellationToken = default)
     {
         if (!await _favoriteRepository.ExistsAsync(userId, carId, cancellationToken))
-            return Result<bool>.Failure("Favorite not found.");
+            return Result<bool>.Failure("Favoriten hittades inte.");
 
         await _favoriteRepository.RemoveAsync(userId, carId, cancellationToken);
         return Result<bool>.Success(true);

--- a/backend/src/CarCheck.Application/Gdpr/GdprService.cs
+++ b/backend/src/CarCheck.Application/Gdpr/GdprService.cs
@@ -35,7 +35,7 @@ public class GdprService
     {
         var user = await _userRepository.GetByIdAsync(userId, cancellationToken);
         if (user is null)
-            return Result<UserDataExport>.Failure("User not found.");
+            return Result<UserDataExport>.Failure("Användare hittades inte.");
 
         var searchHistory = await _searchHistoryRepository.GetByUserIdAsync(userId, 1, 10000, cancellationToken);
         var favorites = await _favoriteRepository.GetByUserIdAsync(userId, 1, 10000, cancellationToken);
@@ -58,7 +58,7 @@ public class GdprService
     {
         var user = await _userRepository.GetByIdAsync(userId, cancellationToken);
         if (user is null)
-            return Result<DataDeletionResponse>.Failure("User not found.");
+            return Result<DataDeletionResponse>.Failure("Användare hittades inte.");
 
         // Revoke all sessions
         await _refreshTokenRepository.RevokeAllForUserAsync(userId, cancellationToken);
@@ -71,7 +71,7 @@ public class GdprService
 
         return Result<DataDeletionResponse>.Success(new DataDeletionResponse(
             true,
-            "Your account and all associated data have been permanently deleted.",
+            "Ditt konto och all tillhörande data har raderats permanent.",
             DateTime.UtcNow));
     }
 }

--- a/backend/src/CarCheck.Application/History/SearchHistoryService.cs
+++ b/backend/src/CarCheck.Application/History/SearchHistoryService.cs
@@ -51,10 +51,10 @@ public class SearchHistoryService
     {
         var entry = await _searchHistoryRepository.GetByIdAsync(entryId, cancellationToken);
         if (entry is null)
-            return Result<bool>.Failure("Entry not found.");
+            return Result<bool>.Failure("Historikposten hittades inte.");
 
         if (entry.UserId != userId)
-            return Result<bool>.Failure("Entry not found.");
+            return Result<bool>.Failure("Historikposten hittades inte.");
 
         await _searchHistoryRepository.DeleteByIdAsync(entryId, cancellationToken);
         return Result<bool>.Success(true);

--- a/backend/src/CarCheck.Application/Interfaces/IEmailService.cs
+++ b/backend/src/CarCheck.Application/Interfaces/IEmailService.cs
@@ -3,4 +3,5 @@ namespace CarCheck.Application.Interfaces;
 public interface IEmailService
 {
     Task SendPasswordResetAsync(string toEmail, string resetToken, CancellationToken cancellationToken = default);
+    Task SendEmailVerificationAsync(string toEmail, string verificationToken, CancellationToken cancellationToken = default);
 }

--- a/backend/src/CarCheck.Domain/Entities/CreditTransaction.cs
+++ b/backend/src/CarCheck.Domain/Entities/CreditTransaction.cs
@@ -1,0 +1,54 @@
+namespace CarCheck.Domain.Entities;
+
+public class CreditTransaction
+{
+    public Guid Id { get; private set; }
+    public Guid UserId { get; private set; }
+    public string Type { get; private set; } = string.Empty; // "credits" | "subscription" | "trial"
+    public int? Credits { get; private set; }
+    public int AmountOre { get; private set; }
+    public string Description { get; private set; } = string.Empty;
+    public string? ExternalPaymentId { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+
+    private CreditTransaction() { }
+
+    public static CreditTransaction CreateCredits(Guid userId, int credits, int amountOre, string? externalPaymentId)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Type = "credits",
+            Credits = credits,
+            AmountOre = amountOre,
+            Description = $"{credits} {(credits == 1 ? "sökning" : "sökningar")}",
+            ExternalPaymentId = externalPaymentId,
+            CreatedAt = DateTime.UtcNow
+        };
+
+    public static CreditTransaction CreateSubscription(Guid userId, int amountOre, string? externalPaymentId)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Type = "subscription",
+            Credits = null,
+            AmountOre = amountOre,
+            Description = "Månadsplan — obegränsade sökningar",
+            ExternalPaymentId = externalPaymentId,
+            CreatedAt = DateTime.UtcNow
+        };
+
+    public static CreditTransaction CreateTrial(Guid userId)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Type = "trial",
+            Credits = 1,
+            AmountOre = 0,
+            Description = "Gratis provssökning vid kontoaktivering",
+            ExternalPaymentId = null,
+            CreatedAt = DateTime.UtcNow
+        };
+}

--- a/backend/src/CarCheck.Domain/Entities/EmailVerification.cs
+++ b/backend/src/CarCheck.Domain/Entities/EmailVerification.cs
@@ -1,0 +1,34 @@
+namespace CarCheck.Domain.Entities;
+
+public class EmailVerification
+{
+    public Guid Id { get; private set; }
+    public Guid UserId { get; private set; }
+    public string Token { get; private set; } = string.Empty;
+    public DateTime ExpiresAt { get; private set; }
+    public bool Used { get; private set; }
+
+    private EmailVerification() { }
+
+    public static EmailVerification Create(Guid userId, TimeSpan expiration)
+    {
+        if (userId == Guid.Empty)
+            throw new ArgumentException("User ID is required.", nameof(userId));
+
+        return new EmailVerification
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Token = Convert.ToBase64String(Guid.NewGuid().ToByteArray()),
+            ExpiresAt = DateTime.UtcNow.Add(expiration),
+            Used = false
+        };
+    }
+
+    public bool IsExpired() => DateTime.UtcNow > ExpiresAt;
+
+    public void MarkUsed()
+    {
+        Used = true;
+    }
+}

--- a/backend/src/CarCheck.Domain/Interfaces/ICreditTransactionRepository.cs
+++ b/backend/src/CarCheck.Domain/Interfaces/ICreditTransactionRepository.cs
@@ -1,0 +1,10 @@
+using CarCheck.Domain.Entities;
+
+namespace CarCheck.Domain.Interfaces;
+
+public interface ICreditTransactionRepository
+{
+    Task AddAsync(CreditTransaction transaction, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<CreditTransaction>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task<bool> ExistsByExternalPaymentIdAsync(string externalPaymentId, CancellationToken cancellationToken = default);
+}

--- a/backend/src/CarCheck.Domain/Interfaces/IEmailVerificationRepository.cs
+++ b/backend/src/CarCheck.Domain/Interfaces/IEmailVerificationRepository.cs
@@ -1,0 +1,10 @@
+using CarCheck.Domain.Entities;
+
+namespace CarCheck.Domain.Interfaces;
+
+public interface IEmailVerificationRepository
+{
+    Task AddAsync(EmailVerification verification, CancellationToken cancellationToken = default);
+    Task<EmailVerification?> GetByTokenAsync(string token, CancellationToken cancellationToken = default);
+    Task UpdateAsync(EmailVerification verification, CancellationToken cancellationToken = default);
+}

--- a/backend/src/CarCheck.Infrastructure/DependencyInjection.cs
+++ b/backend/src/CarCheck.Infrastructure/DependencyInjection.cs
@@ -41,6 +41,8 @@ public static class DependencyInjection
         services.AddScoped<ITokenService, JwtTokenService>();
         services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
         services.AddScoped<IPasswordResetRepository, PasswordResetRepository>();
+        services.AddScoped<IEmailVerificationRepository, EmailVerificationRepository>();
+        services.AddScoped<ICreditTransactionRepository, CreditTransactionRepository>();
         services.AddScoped<ISecurityEventLogger, SecurityEventLogger>();
         services.AddScoped<AuthService>();
 

--- a/backend/src/CarCheck.Infrastructure/External/ResendEmailService.cs
+++ b/backend/src/CarCheck.Infrastructure/External/ResendEmailService.cs
@@ -52,4 +52,39 @@ public class ResendEmailService : IEmailService
             _logger.LogError("Resend API error {Status}: {Body}", response.StatusCode, body);
         }
     }
+
+    public async Task SendEmailVerificationAsync(string toEmail, string verificationToken, CancellationToken cancellationToken = default)
+    {
+        var verifyUrl = $"{_frontendBaseUrl}/verify-email?token={verificationToken}";
+        var payload = new
+        {
+            from = "CarCheck <onboarding@resend.dev>",
+            to = new[] { toEmail },
+            subject = "Verifiera din e-postadress",
+            html = $"""
+                <div style="font-family:sans-serif;max-width:480px;margin:0 auto">
+                  <h2 style="color:#1e3a5f">Välkommen till CarCheck!</h2>
+                  <p>Klicka på knappen nedan för att verifiera din e-postadress och aktivera din gratis sökning.</p>
+                  <p>Länken är giltig i <strong>24 timmar</strong>.</p>
+                  <a href="{verifyUrl}"
+                     style="display:inline-block;margin:16px 0;padding:12px 24px;background:#2563eb;color:#fff;text-decoration:none;border-radius:8px;font-weight:600">
+                    Verifiera e-postadress
+                  </a>
+                  <p style="color:#6b7280;font-size:13px">
+                    Om du inte skapade ett konto hos CarCheck kan du ignorera detta mail.
+                  </p>
+                  <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0"/>
+                  <p style="color:#9ca3af;font-size:12px">CarCheck &mdash; Kontrollera bilen innan köpet</p>
+                </div>
+                """
+        };
+
+        var response = await _http.PostAsJsonAsync("emails", payload, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogError("Resend API error {Status}: {Body}", response.StatusCode, body);
+        }
+    }
 }

--- a/backend/src/CarCheck.Infrastructure/Persistence/CarCheckDbContext.cs
+++ b/backend/src/CarCheck.Infrastructure/Persistence/CarCheckDbContext.cs
@@ -14,6 +14,8 @@ public class CarCheckDbContext : DbContext
     public DbSet<SearchHistory> SearchHistories => Set<SearchHistory>();
     public DbSet<Favorite> Favorites => Set<Favorite>();
     public DbSet<PasswordReset> PasswordResets => Set<PasswordReset>();
+    public DbSet<EmailVerification> EmailVerifications => Set<EmailVerification>();
+    public DbSet<CreditTransaction> CreditTransactions => Set<CreditTransaction>();
     public DbSet<SecurityEvent> SecurityEvents => Set<SecurityEvent>();
     public DbSet<RefreshTokenEntry> RefreshTokens => Set<RefreshTokenEntry>();
     public DbSet<Subscription> Subscriptions => Set<Subscription>();

--- a/backend/src/CarCheck.Infrastructure/Persistence/Configurations/CreditTransactionConfiguration.cs
+++ b/backend/src/CarCheck.Infrastructure/Persistence/Configurations/CreditTransactionConfiguration.cs
@@ -1,0 +1,50 @@
+using CarCheck.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CarCheck.Infrastructure.Persistence.Configurations;
+
+public class CreditTransactionConfiguration : IEntityTypeConfiguration<CreditTransaction>
+{
+    public void Configure(EntityTypeBuilder<CreditTransaction> builder)
+    {
+        builder.ToTable("credit_transactions");
+
+        builder.HasKey(t => t.Id);
+        builder.Property(t => t.Id).HasColumnName("id");
+
+        builder.Property(t => t.UserId)
+            .HasColumnName("user_id")
+            .IsRequired();
+
+        builder.Property(t => t.Type)
+            .HasColumnName("type")
+            .HasMaxLength(32)
+            .IsRequired();
+
+        builder.Property(t => t.Credits)
+            .HasColumnName("credits");
+
+        builder.Property(t => t.AmountOre)
+            .HasColumnName("amount_ore")
+            .IsRequired();
+
+        builder.Property(t => t.Description)
+            .HasColumnName("description")
+            .HasMaxLength(256)
+            .IsRequired();
+
+        builder.Property(t => t.ExternalPaymentId)
+            .HasColumnName("external_payment_id")
+            .HasMaxLength(256);
+
+        builder.Property(t => t.CreatedAt)
+            .HasColumnName("created_at")
+            .IsRequired();
+
+        builder.HasIndex(t => t.UserId);
+        builder.HasIndex(t => t.ExternalPaymentId)
+            .IsUnique()
+            .HasFilter("external_payment_id IS NOT NULL");
+    }
+}

--- a/backend/src/CarCheck.Infrastructure/Persistence/Configurations/EmailVerificationConfiguration.cs
+++ b/backend/src/CarCheck.Infrastructure/Persistence/Configurations/EmailVerificationConfiguration.cs
@@ -1,0 +1,36 @@
+using CarCheck.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CarCheck.Infrastructure.Persistence.Configurations;
+
+public class EmailVerificationConfiguration : IEntityTypeConfiguration<EmailVerification>
+{
+    public void Configure(EntityTypeBuilder<EmailVerification> builder)
+    {
+        builder.ToTable("email_verifications");
+
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("id");
+
+        builder.Property(e => e.UserId)
+            .HasColumnName("user_id")
+            .IsRequired();
+
+        builder.Property(e => e.Token)
+            .HasColumnName("token")
+            .HasMaxLength(512)
+            .IsRequired();
+
+        builder.Property(e => e.ExpiresAt)
+            .HasColumnName("expires_at")
+            .IsRequired();
+
+        builder.Property(e => e.Used)
+            .HasColumnName("used")
+            .HasDefaultValue(false);
+
+        builder.HasIndex(e => e.UserId);
+        builder.HasIndex(e => e.Token);
+    }
+}

--- a/backend/src/CarCheck.Infrastructure/Persistence/Migrations/20260311100000_AddEmailVerifications.cs
+++ b/backend/src/CarCheck.Infrastructure/Persistence/Migrations/20260311100000_AddEmailVerifications.cs
@@ -1,0 +1,46 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CarCheck.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmailVerifications : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "email_verifications",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    token = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    expires_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    used = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_email_verifications", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_email_verifications_token",
+                table: "email_verifications",
+                column: "token");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_email_verifications_user_id",
+                table: "email_verifications",
+                column: "user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "email_verifications");
+        }
+    }
+}

--- a/backend/src/CarCheck.Infrastructure/Persistence/Migrations/20260311110000_AddCreditTransactions.cs
+++ b/backend/src/CarCheck.Infrastructure/Persistence/Migrations/20260311110000_AddCreditTransactions.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CarCheck.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCreditTransactions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "credit_transactions",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    type = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    credits = table.Column<int>(type: "integer", nullable: true),
+                    amount_ore = table.Column<int>(type: "integer", nullable: false),
+                    description = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    external_payment_id = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_credit_transactions", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_credit_transactions_user_id",
+                table: "credit_transactions",
+                column: "user_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_credit_transactions_external_payment_id",
+                table: "credit_transactions",
+                column: "external_payment_id",
+                unique: true,
+                filter: "external_payment_id IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "credit_transactions");
+        }
+    }
+}

--- a/backend/src/CarCheck.Infrastructure/Persistence/Repositories/CreditTransactionRepository.cs
+++ b/backend/src/CarCheck.Infrastructure/Persistence/Repositories/CreditTransactionRepository.cs
@@ -1,0 +1,35 @@
+using CarCheck.Domain.Entities;
+using CarCheck.Domain.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace CarCheck.Infrastructure.Persistence.Repositories;
+
+public class CreditTransactionRepository : ICreditTransactionRepository
+{
+    private readonly CarCheckDbContext _context;
+
+    public CreditTransactionRepository(CarCheckDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task AddAsync(CreditTransaction transaction, CancellationToken cancellationToken = default)
+    {
+        await _context.CreditTransactions.AddAsync(transaction, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<CreditTransaction>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await _context.CreditTransactions
+            .Where(t => t.UserId == userId)
+            .OrderByDescending(t => t.CreatedAt)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<bool> ExistsByExternalPaymentIdAsync(string externalPaymentId, CancellationToken cancellationToken = default)
+    {
+        return await _context.CreditTransactions
+            .AnyAsync(t => t.ExternalPaymentId == externalPaymentId, cancellationToken);
+    }
+}

--- a/backend/src/CarCheck.Infrastructure/Persistence/Repositories/EmailVerificationRepository.cs
+++ b/backend/src/CarCheck.Infrastructure/Persistence/Repositories/EmailVerificationRepository.cs
@@ -1,0 +1,33 @@
+using CarCheck.Domain.Entities;
+using CarCheck.Domain.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace CarCheck.Infrastructure.Persistence.Repositories;
+
+public class EmailVerificationRepository : IEmailVerificationRepository
+{
+    private readonly CarCheckDbContext _context;
+
+    public EmailVerificationRepository(CarCheckDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task AddAsync(EmailVerification verification, CancellationToken cancellationToken = default)
+    {
+        await _context.EmailVerifications.AddAsync(verification, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<EmailVerification?> GetByTokenAsync(string token, CancellationToken cancellationToken = default)
+    {
+        return await _context.EmailVerifications
+            .FirstOrDefaultAsync(e => e.Token == token, cancellationToken);
+    }
+
+    public async Task UpdateAsync(EmailVerification verification, CancellationToken cancellationToken = default)
+    {
+        _context.EmailVerifications.Update(verification);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/backend/tests/CarCheck.Application.Tests/Auth/AuthServiceTests.cs
+++ b/backend/tests/CarCheck.Application.Tests/Auth/AuthServiceTests.cs
@@ -16,6 +16,8 @@ public class AuthServiceTests
     private readonly IRefreshTokenRepository _refreshTokenRepository;
     private readonly ISecurityEventLogger _securityEventLogger;
     private readonly IPasswordResetRepository _passwordResetRepository;
+    private readonly IEmailVerificationRepository _emailVerificationRepository;
+    private readonly ICreditTransactionRepository _transactionRepository;
     private readonly IEmailService _emailService;
     private readonly AuthService _sut;
 
@@ -27,6 +29,8 @@ public class AuthServiceTests
         _refreshTokenRepository = Substitute.For<IRefreshTokenRepository>();
         _securityEventLogger = Substitute.For<ISecurityEventLogger>();
         _passwordResetRepository = Substitute.For<IPasswordResetRepository>();
+        _emailVerificationRepository = Substitute.For<IEmailVerificationRepository>();
+        _transactionRepository = Substitute.For<ICreditTransactionRepository>();
         _emailService = Substitute.For<IEmailService>();
 
         _sut = new AuthService(
@@ -36,6 +40,8 @@ public class AuthServiceTests
             _refreshTokenRepository,
             _securityEventLogger,
             _passwordResetRepository,
+            _emailVerificationRepository,
+            _transactionRepository,
             _emailService);
     }
 

--- a/backend/tests/CarCheck.Application.Tests/Billing/SubscriptionServiceTests.cs
+++ b/backend/tests/CarCheck.Application.Tests/Billing/SubscriptionServiceTests.cs
@@ -14,6 +14,7 @@ public class SubscriptionServiceTests
     private readonly IUserRepository _userRepository;
     private readonly IBillingProvider _billingProvider;
     private readonly ISecurityEventLogger _securityEventLogger;
+    private readonly ICreditTransactionRepository _transactionRepository;
     private readonly SubscriptionService _sut;
 
     public SubscriptionServiceTests()
@@ -22,12 +23,14 @@ public class SubscriptionServiceTests
         _userRepository = Substitute.For<IUserRepository>();
         _billingProvider = Substitute.For<IBillingProvider>();
         _securityEventLogger = Substitute.For<ISecurityEventLogger>();
+        _transactionRepository = Substitute.For<ICreditTransactionRepository>();
 
         _sut = new SubscriptionService(
             _subscriptionRepository,
             _userRepository,
             _billingProvider,
-            _securityEventLogger);
+            _securityEventLogger,
+            _transactionRepository);
     }
 
     // ===== Get Current Subscription =====

--- a/frontend/src/api/auth.api.ts
+++ b/frontend/src/api/auth.api.ts
@@ -34,4 +34,7 @@ export const authApi = {
 
   resetPassword: (data: ResetPasswordRequest) =>
     apiClient.post('/auth/reset-password', data),
+
+  verifyEmail: (token: string) =>
+    apiClient.get('/auth/verify-email', { params: { token } }),
 }

--- a/frontend/src/api/billing.api.ts
+++ b/frontend/src/api/billing.api.ts
@@ -7,6 +7,7 @@ import type {
   CreditPackResponse,
   BuyCreditsRequest,
   CreditsBalanceResponse,
+  TransactionResponse,
 } from '@/types/billing.types'
 
 export const billingApi = {
@@ -30,4 +31,7 @@ export const billingApi = {
 
   cancelSubscription: () =>
     apiClient.post('/billing/cancel'),
+
+  getTransactions: () =>
+    apiClient.get<TransactionResponse[]>('/billing/transactions'),
 }

--- a/frontend/src/features/auth/register-page.tsx
+++ b/frontend/src/features/auth/register-page.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Link, useNavigate, useLocation } from 'react-router'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Car, Lock, Zap, Trophy, ChevronRight, Search } from 'lucide-react'
+import { Car, Lock, Zap, Trophy, ChevronRight, Search, Mail } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -24,6 +24,7 @@ export function RegisterPage() {
   const { register: registerUser } = useAuth()
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [registeredEmail, setRegisteredEmail] = useState<string | null>(null)
 
   const regNumber = (location.state as { regNumber?: string })?.regNumber
 
@@ -55,7 +56,7 @@ export function RegisterPage() {
     setIsSubmitting(true)
     try {
       await registerUser({ email: data.email, password: data.password })
-      navigate('/login', { state: { registered: true, regNumber } })
+      setRegisteredEmail(data.email)
     } catch (err) {
       const axiosError = err as AxiosError<ApiError>
       setError(axiosError.response?.data?.error || 'Registreringen misslyckades. Försök igen.')
@@ -67,6 +68,35 @@ export function RegisterPage() {
   const formattedReg = regNumber
     ? regNumber.replace(/^([A-Za-z]{3})(\d{3})$/, '$1 $2').toUpperCase()
     : null
+
+  if (registeredEmail) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-12">
+        <div className="w-full max-w-sm space-y-8">
+          <div className="flex items-center gap-2">
+            <Car className="h-5 w-5 text-blue-400" />
+            <span className="text-base font-bold">CarCheck</span>
+          </div>
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-600/10">
+            <Mail className="h-6 w-6 text-blue-400" />
+          </div>
+          <div className="space-y-1">
+            <h1 className="text-2xl font-bold">Kolla din e-post</h1>
+            <p className="text-sm text-muted-foreground">
+              Vi har skickat en verifieringslänk till <strong>{registeredEmail}</strong>.
+              Klicka på länken för att aktivera ditt konto och få din gratis sökning.
+            </p>
+          </div>
+          <Link
+            to="/login"
+            className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Gå till inloggning
+          </Link>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="flex min-h-screen">

--- a/frontend/src/features/auth/verify-email-page.tsx
+++ b/frontend/src/features/auth/verify-email-page.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react'
+import { Link, useSearchParams } from 'react-router'
+import { Car, CheckCircle, XCircle, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { authApi } from '@/api/auth.api'
+
+export function VerifyEmailPage() {
+  const [searchParams] = useSearchParams()
+  const token = searchParams.get('token')
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  useEffect(() => {
+    if (!token) {
+      setStatus('error')
+      setErrorMessage('Ingen verifieringslänk hittades.')
+      return
+    }
+
+    authApi.verifyEmail(token)
+      .then(() => setStatus('success'))
+      .catch((err) => {
+        const msg = err?.response?.data?.error ?? 'Ogiltig eller utgången verifieringslänk.'
+        setErrorMessage(msg)
+        setStatus('error')
+      })
+  }, [token])
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-12">
+      <div className="w-full max-w-sm space-y-8">
+
+        <div className="flex items-center gap-2">
+          <Car className="h-5 w-5 text-blue-400" />
+          <span className="text-base font-bold">CarCheck</span>
+        </div>
+
+        {status === 'loading' && (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <Loader2 className="h-10 w-10 animate-spin text-blue-400" />
+            <p className="text-sm text-muted-foreground">Verifierar din e-postadress…</p>
+          </div>
+        )}
+
+        {status === 'success' && (
+          <div className="space-y-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-600/10">
+              <CheckCircle className="h-6 w-6 text-green-400" />
+            </div>
+            <div className="space-y-1">
+              <h1 className="text-2xl font-bold">E-posten verifierad!</h1>
+              <p className="text-sm text-muted-foreground">
+                Ditt konto är aktiverat och du har fått <strong>1 gratis sökning</strong>. Logga in för att komma igång.
+              </p>
+            </div>
+            <Button asChild className="w-full bg-blue-600 hover:bg-blue-500">
+              <Link to="/login">Logga in</Link>
+            </Button>
+          </div>
+        )}
+
+        {status === 'error' && (
+          <div className="space-y-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-600/10">
+              <XCircle className="h-6 w-6 text-red-400" />
+            </div>
+            <div className="space-y-1">
+              <h1 className="text-2xl font-bold">Verifiering misslyckades</h1>
+              <p className="text-sm text-muted-foreground">{errorMessage}</p>
+            </div>
+            <Button asChild variant="outline" className="w-full">
+              <Link to="/login">Gå till inloggning</Link>
+            </Button>
+          </div>
+        )}
+
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/billing/billing-page.tsx
+++ b/frontend/src/features/billing/billing-page.tsx
@@ -3,13 +3,21 @@ import { useSearchParams } from 'react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Check, Zap, Infinity, CreditCard, Calendar } from 'lucide-react'
-import { useSubscription, useCreateCheckout, useCancelSubscription, useCreditsCheckout, useCreditPackages } from '@/hooks/use-billing'
+import { Check, Zap, Infinity, CreditCard, Calendar, Receipt } from 'lucide-react'
+import {
+  useSubscription,
+  useCreateCheckout,
+  useCancelSubscription,
+  useCreditsCheckout,
+  useCreditPackages,
+  useTransactions,
+} from '@/hooks/use-billing'
 import { LoadingSpinner } from '@/components/common/loading-spinner'
 import { ErrorDisplay } from '@/components/common/error-display'
 import { formatDate } from '@/lib/format'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
+import type { TransactionResponse } from '@/types/billing.types'
 
 const MONTHLY_TIER = 1 // SubscriptionTier.Pro = monthly unlimited
 
@@ -20,6 +28,46 @@ function formatSek(amount: number) {
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   }).format(amount)
+}
+
+function TransactionBadge({ type }: { type: TransactionResponse['type'] }) {
+  if (type === 'subscription') return <Badge className="bg-green-600 hover:bg-green-600">Månadsplan</Badge>
+  if (type === 'trial') return <Badge variant="secondary">Provssökning</Badge>
+  return <Badge className="bg-blue-600 hover:bg-blue-600">Krediter</Badge>
+}
+
+function PurchaseHistory() {
+  const { data: transactions, isLoading } = useTransactions()
+
+  if (isLoading) return null
+  if (!transactions?.length) return null
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Receipt className="h-5 w-5 text-muted-foreground" />
+        <h2 className="text-lg font-semibold">Köphistorik</h2>
+      </div>
+      <Card>
+        <CardContent className="pt-4 divide-y divide-border">
+          {transactions.map((t) => (
+            <div key={t.id} className="flex items-center justify-between py-3 first:pt-0 last:pb-0">
+              <div className="space-y-0.5">
+                <p className="text-sm font-medium">{t.description}</p>
+                <p className="text-xs text-muted-foreground">{formatDate(t.createdAt)}</p>
+              </div>
+              <div className="flex items-center gap-3 shrink-0">
+                <TransactionBadge type={t.type} />
+                <span className="text-sm font-semibold text-right min-w-[60px]">
+                  {t.amountSek > 0 ? formatSek(t.amountSek) : 'Gratis'}
+                </span>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  )
 }
 
 export function BillingPage() {
@@ -100,11 +148,6 @@ export function BillingPage() {
                 <p className="text-4xl font-black text-foreground mt-1">
                   {hasMonthly ? <Infinity className="h-8 w-8 text-blue-500 inline" /> : credits}
                 </p>
-                {!hasMonthly && (
-                  <p className="text-xs text-muted-foreground mt-1">
-                    + {3} gratis per dag
-                  </p>
-                )}
               </div>
               <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-600/10">
                 <Zap className="h-7 w-7 text-blue-500" />
@@ -245,6 +288,9 @@ export function BillingPage() {
           </CardContent>
         </Card>
       </div>
+
+      {/* Purchase history */}
+      <PurchaseHistory />
     </div>
   )
 }

--- a/frontend/src/hooks/use-billing.ts
+++ b/frontend/src/hooks/use-billing.ts
@@ -47,6 +47,13 @@ export function useCreditsCheckout() {
   })
 }
 
+export function useTransactions() {
+  return useQuery({
+    queryKey: queryKeys.billing.transactions,
+    queryFn: () => billingApi.getTransactions().then((r) => r.data),
+  })
+}
+
 export function useCancelSubscription() {
   const queryClient = useQueryClient()
   return useMutation({

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -17,5 +17,6 @@ export const queryKeys = {
   billing: {
     tiers: ['billing', 'tiers'] as const,
     subscription: ['billing', 'subscription'] as const,
+    transactions: ['billing', 'transactions'] as const,
   },
 }

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -9,6 +9,7 @@ const LoginPage = lazy(() => import('@/features/auth/login-page').then(m => ({ d
 const RegisterPage = lazy(() => import('@/features/auth/register-page').then(m => ({ default: m.RegisterPage })))
 const ForgotPasswordPage = lazy(() => import('@/features/auth/forgot-password-page').then(m => ({ default: m.ForgotPasswordPage })))
 const ResetPasswordPage = lazy(() => import('@/features/auth/reset-password-page').then(m => ({ default: m.ResetPasswordPage })))
+const VerifyEmailPage = lazy(() => import('@/features/auth/verify-email-page').then(m => ({ default: m.VerifyEmailPage })))
 const PrivacyPage = lazy(() => import('@/features/legal/privacy-page').then(m => ({ default: m.PrivacyPage })))
 const TermsPage = lazy(() => import('@/features/legal/terms-page').then(m => ({ default: m.TermsPage })))
 const DashboardPage = lazy(() => import('@/features/dashboard/dashboard-page').then(m => ({ default: m.DashboardPage })))
@@ -42,6 +43,7 @@ export const router = createBrowserRouter([
       { path: '/register', element: <Lazy><RegisterPage /></Lazy> },
       { path: '/forgot-password', element: <Lazy><ForgotPasswordPage /></Lazy> },
       { path: '/reset-password', element: <Lazy><ResetPasswordPage /></Lazy> },
+      { path: '/verify-email', element: <Lazy><VerifyEmailPage /></Lazy> },
       { path: '/privacy', element: <Lazy><PrivacyPage /></Lazy> },
       { path: '/terms', element: <Lazy><TermsPage /></Lazy> },
       { path: '/share/:carId', element: <Lazy><SharePage /></Lazy> },

--- a/frontend/src/types/billing.types.ts
+++ b/frontend/src/types/billing.types.ts
@@ -49,3 +49,12 @@ export interface CreditsBalanceResponse {
   credits: number
   hasMonthlySubscription: boolean
 }
+
+export interface TransactionResponse {
+  id: string
+  type: 'credits' | 'subscription' | 'trial'
+  credits: number | null
+  amountSek: number
+  description: string
+  createdAt: string
+}


### PR DESCRIPTION
## Summary

- **E-postverifiering**: Ny token-baserad verifiering vid registrering (24h). Overifierade konton blockeras från sökning (403). Frontend visar bekräftelsesida efter registrering + `/verify-email`-sida.
- **1 gratis provssökning**: Ges när e-post verifieras. Ersätter det missbrukbara 3/dag-systemet. Fixar även bugg där historiktömning nollställde gratiskvoten.
- **Köphistorik** (`credit_transactions`): Oföränderlig ledger för krediter, prenumerationer och gratis prov. Visas på billing-sidan.
- **Idempotent webhook**: Stripe-session-ID som dedup-nyckel — fixar kritisk bugg där Stripe dubbelskickar webhooks och användaren fick dubbla krediter.
- **Svenska felmeddelanden**: Alla 33 engelska strängar översatta i backend.

## Databasmigrationer att köra
```sql
CREATE TABLE email_verifications (
  id UUID PRIMARY KEY,
  user_id UUID NOT NULL,
  token VARCHAR(512) NOT NULL,
  expires_at TIMESTAMPTZ NOT NULL,
  used BOOLEAN NOT NULL DEFAULT false
);
CREATE INDEX ON email_verifications(user_id);
CREATE INDEX ON email_verifications(token);

CREATE TABLE credit_transactions (
  id UUID PRIMARY KEY,
  user_id UUID NOT NULL,
  type VARCHAR(32) NOT NULL,
  credits INTEGER,
  amount_ore INTEGER NOT NULL,
  description VARCHAR(256) NOT NULL,
  external_payment_id VARCHAR(256),
  created_at TIMESTAMPTZ NOT NULL
);
CREATE INDEX ON credit_transactions(user_id);
CREATE UNIQUE INDEX ON credit_transactions(external_payment_id) WHERE external_payment_id IS NOT NULL;
```

## Test plan
- [ ] Registrera nytt konto → bekräftelsesida visas
- [ ] Försök söka utan verifiering → 403 med förklarande meddelande
- [ ] Klicka verifieringslänk → `/verify-email` visar success + 1 kredit i header
- [ ] Gör en sökning → krediten förbrukas
- [ ] Köp krediter via Stripe testläge → köphistorik visas på billing-sidan
- [ ] Skicka samma Stripe-webhook två gånger → inga dubbla krediter

🤖 Generated with [Claude Code](https://claude.com/claude-code)