### PR TITLE
fix: byt avsändare till noreply@carcheck.se

### DIFF
--- a/backend/src/CarCheck.Infrastructure/External/ResendEmailService.cs
+++ b/backend/src/CarCheck.Infrastructure/External/ResendEmailService.cs
@@ -23,7 +23,7 @@ public class ResendEmailService : IEmailService
         var resetUrl = $"{_frontendBaseUrl}/reset-password?token={resetToken}";
         var payload = new
         {
-            from = "CarCheck <onboarding@resend.dev>",
+            from = "CarCheck <noreply@carcheck.se>",
             to = new[] { toEmail },
             subject = "Återställ ditt lösenord",
             html = $"""
@@ -58,7 +58,7 @@ public class ResendEmailService : IEmailService
         var verifyUrl = $"{_frontendBaseUrl}/verify-email?token={verificationToken}";
         var payload = new
         {
-            from = "CarCheck <onboarding@resend.dev>",
+            from = "CarCheck <noreply@carcheck.se>",
             to = new[] { toEmail },
             subject = "Verifiera din e-postadress",
             html = $"""


### PR DESCRIPTION
Byter from-adress från onboarding@resend.dev till noreply@carcheck.se efter domänverifiering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)