### PR TITLE
fix: 7-bug sweep — quota NaN, 402 toast, cancel dialog, PDF, mobile credits, resend, webhook log

### DIFF
--- a/backend/src/CarCheck.API/Endpoints/BillingEndpoints.cs
+++ b/backend/src/CarCheck.API/Endpoints/BillingEndpoints.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using CarCheck.Application.Billing.DTOs;
 using CarCheck.Domain.Enums;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Stripe;
 using AppSubscriptionService = CarCheck.Application.Billing.SubscriptionService;
 
@@ -107,8 +108,9 @@ public static class BillingEndpoints
         .WithName("BuyCreditsCheckout")
         .RequireAuthorization();
 
-        group.MapPost("/webhook", async (HttpRequest request, AppSubscriptionService subscriptionService, IConfiguration config) =>
+        group.MapPost("/webhook", async (HttpRequest request, AppSubscriptionService subscriptionService, IConfiguration config, ILoggerFactory loggerFactory) =>
         {
+            var logger = loggerFactory.CreateLogger("BillingWebhook");
             string json;
             using (var reader = new StreamReader(request.Body))
                 json = await reader.ReadToEndAsync();
@@ -127,8 +129,9 @@ public static class BillingEndpoints
                     stripeEvent = EventUtility.ParseEvent(json);
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                logger.LogWarning(ex, "Stripe webhook signature validation failed");
                 return Results.BadRequest();
             }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,7 @@
 import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios'
 import { getTokens, setTokens, clearTokens } from '@/lib/token'
 import { useQuotaStore } from '@/stores/quota.store'
+import { toast } from 'sonner'
 
 const apiClient = axios.create({
   baseURL: '/api',
@@ -39,11 +40,12 @@ apiClient.interceptors.response.use(
     const quotaRemaining = response.headers['x-dailyquota-remaining']
     const tier = response.headers['x-subscription-tier']
     if (quotaLimit) {
+      const parsedRemaining = quotaRemaining === 'unlimited' ? 'unlimited' : (parseInt(quotaRemaining, 10) || 0)
       useQuotaStore.getState().setQuota({
         limit: quotaLimit === 'unlimited' ? 'unlimited'
           : quotaLimit === 'credits' ? 'credits'
-          : parseInt(quotaLimit, 10),
-        remaining: quotaRemaining === 'unlimited' ? 'unlimited' : parseInt(quotaRemaining, 10),
+          : (parseInt(quotaLimit, 10) || 0),
+        remaining: parsedRemaining,
         tier: tier || 'Free',
       })
     }
@@ -54,8 +56,8 @@ apiClient.interceptors.response.use(
     const rlReset = response.headers['x-ratelimit-reset']
     if (rlLimit) {
       useQuotaStore.getState().setRateLimit({
-        limit: parseInt(rlLimit, 10),
-        remaining: parseInt(rlRemaining, 10),
+        limit: parseInt(rlLimit, 10) || 0,
+        remaining: parseInt(rlRemaining, 10) || 0,
         resetsAt: rlReset,
       })
     }
@@ -107,6 +109,14 @@ apiClient.interceptors.response.use(
       } finally {
         isRefreshing = false
       }
+    }
+
+    // 402 = out of credits/quota — navigate to billing
+    if (error.response?.status === 402) {
+      toast.error('Du har inga sökningar kvar.', {
+        action: { label: 'Köp sökningar', onClick: () => { window.location.href = '/billing' } },
+        duration: 6000,
+      })
     }
 
     return Promise.reject(error)

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -91,7 +91,7 @@ function CreditsChip() {
   return (
     <Link
       to="/billing"
-      className="hidden md:flex items-center gap-1 rounded-full border border-blue-500/40 bg-blue-500/10 px-2.5 py-0.5 text-xs font-semibold text-blue-400 hover:bg-blue-500/20 transition-colors"
+      className="flex items-center gap-1 rounded-full border border-blue-500/40 bg-blue-500/10 px-2.5 py-0.5 text-xs font-semibold text-blue-400 hover:bg-blue-500/20 transition-colors"
     >
       <Zap className="h-3 w-3" />
       {label}

--- a/frontend/src/features/auth/login-page.tsx
+++ b/frontend/src/features/auth/login-page.tsx
@@ -10,6 +10,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { useAuth } from '@/hooks/use-auth'
 import { authApi } from '@/api/auth.api'
 import { loginSchema, type LoginFormData } from '@/lib/validators'
+import { toast } from 'sonner'
 import type { AxiosError } from 'axios'
 
 const FEATURES = [
@@ -72,7 +73,7 @@ export function LoginPage() {
       await authApi.resendVerification(unverifiedEmail)
       setResendSent(true)
     } catch {
-      // fail silently — backend always returns 200
+      toast.error('Kunde inte skicka verifieringslänk. Försök igen.')
     }
   }
 

--- a/frontend/src/features/billing/billing-page.tsx
+++ b/frontend/src/features/billing/billing-page.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Check, Zap, Infinity, CreditCard, Calendar, Receipt } from 'lucide-react'
 import {
   useSubscription,
@@ -79,6 +80,7 @@ export function BillingPage() {
   const creditsCheckoutMutation = useCreditsCheckout()
   const cancelMutation = useCancelSubscription()
   const [cancelOpen, setCancelOpen] = useState(false)
+  const [cancelError, setCancelError] = useState<string | null>(null)
 
   useEffect(() => {
     if (searchParams.get('success') === 'true') {
@@ -126,14 +128,14 @@ export function BillingPage() {
   }
 
   const handleCancel = () => {
+    setCancelError(null)
     cancelMutation.mutate(undefined, {
       onSuccess: () => {
         setCancelOpen(false)
         toast.success('Månadsplanen avbruten')
       },
       onError: () => {
-        setCancelOpen(false)
-        toast.error('Kunde inte avbryta månadsplanen. Försök igen.')
+        setCancelError('Något gick fel. Försök igen eller kontakta support.')
       },
     })
   }
@@ -300,7 +302,7 @@ export function BillingPage() {
       <PurchaseHistory />
 
       {/* Cancel confirmation dialog */}
-      <Dialog open={cancelOpen} onOpenChange={setCancelOpen}>
+      <Dialog open={cancelOpen} onOpenChange={(open) => { setCancelOpen(open); if (!open) setCancelError(null) }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Avbryt månadsplan?</DialogTitle>
@@ -308,6 +310,11 @@ export function BillingPage() {
               Din plan avslutas omedelbart. Dina köpta sökningar (krediter) påverkas inte.
             </DialogDescription>
           </DialogHeader>
+          {cancelError && (
+            <Alert variant="destructive">
+              <AlertDescription>{cancelError}</AlertDescription>
+            </Alert>
+          )}
           <DialogFooter>
             <Button variant="outline" onClick={() => setCancelOpen(false)}>
               Behåll planen

--- a/frontend/src/features/car/components/inspection-checklist.tsx
+++ b/frontend/src/features/car/components/inspection-checklist.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react'
 import { ClipboardCheck, Copy, Check, ChevronDown, ChevronRight, Download, Printer } from 'lucide-react'
+import { toast } from 'sonner'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -171,6 +172,7 @@ export function InspectionChecklist({ breakdown, details }: {
   }
 
   const handleDownload = useCallback(async () => {
+    try {
     const { jsPDF } = await import('jspdf')
     const doc = new jsPDF()
     const today = new Date().toLocaleDateString('sv-SE')
@@ -254,6 +256,9 @@ export function InspectionChecklist({ breakdown, details }: {
     )
 
     doc.save('besiktningschecklista.pdf')
+    } catch {
+      toast.error('Kunde inte generera PDF. Försök igen.')
+    }
   }, [groups, checked])
 
   const handleCopy = useCallback(() => {


### PR DESCRIPTION
## Fixes

| # | Bug | Fix |
|---|-----|-----|
| 1 | `parseInt(NaN)` i quota-headers → kvot-chip kunde visa fel | `|| 0` fallback på alla parseInt-anrop |
| 2 | 402 (slut på krediter) visades aldrig för användaren | Interceptor visar toast med action-knapp → /billing |
| 3 | Avbryt-dialog stängdes vid fel — användaren kunde inte försöka igen | Dialog håller sig öppen, visar inline-felmeddelande |
| 4 | PDF-nedladdning kraschade tyst om jsPDF inte laddades | try-catch med error toast |
| 5 | Krediter-chip dold på mobil (`hidden md:flex`) | Synlig på alla skärmstorlekar |
| 6 | "Skicka ny verifieringslänk" misslyckades tyst | toast.error visas vid fel |
| 7 | Stripe webhook-fel loggades aldrig | ILoggerFactory injiceras, fel loggas med LogWarning |

🤖 Generated with [Claude Code](https://claude.com/claude-code)