### PR TITLE
fix: comprehensive security hardening (27 audit findings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    # Only run when backend files change (DEPLOY-004)
+    if: >
+      contains(toJson(github.event.commits), 'backend/') ||
+      github.event_name == 'pull_request'
 
     steps:
       - name: Checkout code
@@ -53,7 +57,12 @@ jobs:
         run: dotnet restore backend/CarCheck.sln
 
       - name: Check for vulnerable packages
-        run: dotnet list backend/CarCheck.sln package --vulnerable --include-transitive 2>&1 | tee vulnerability-report.txt
+        run: |
+          dotnet list backend/CarCheck.sln package --vulnerable --include-transitive 2>&1 | tee vulnerability-report.txt
+          if grep -q "has the following vulnerable packages" vulnerability-report.txt; then
+            echo "::error::Critical vulnerable packages found — see vulnerability-report.txt"
+            exit 1
+          fi
 
       - name: Upload vulnerability report
         if: always()
@@ -61,3 +70,29 @@ jobs:
         with:
           name: vulnerability-report
           path: vulnerability-report.txt
+
+  frontend-typecheck:
+    runs-on: ubuntu-latest
+    # Only run when frontend files change (DEPLOY-004)
+    if: >
+      contains(toJson(github.event.commits), 'frontend/') ||
+      github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: TypeScript type check
+        run: npx tsc --noEmit
+        working-directory: frontend

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -80,9 +80,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run production smoke tests
+      - name: Wait for deployment to stabilise
+        run: sleep 30
+
+      - name: Run production smoke tests (DEPLOY-002)
         run: |
-          echo "Production smoke tests would run here"
           echo "Checking health endpoint..."
-          # curl -f https://api.carcheck.se/health || exit 1
-          echo "Production smoke tests passed (mock)"
+          curl -f --max-time 10 --retry 3 --retry-delay 5 https://api.carcheck.se/health
+          echo ""
+          echo "Verifying security headers..."
+          HEADERS=$(curl -sI https://api.carcheck.se/health)
+          echo "$HEADERS" | grep -i "x-content-type-options" || (echo "::error::Missing X-Content-Type-Options header" && exit 1)
+          echo "$HEADERS" | grep -i "x-frame-options" || (echo "::error::Missing X-Frame-Options header" && exit 1)
+          echo "Production smoke tests passed."

--- a/backend/src/CarCheck.API/Endpoints/AuthEndpoints.cs
+++ b/backend/src/CarCheck.API/Endpoints/AuthEndpoints.cs
@@ -7,6 +7,8 @@ namespace CarCheck.API.Endpoints;
 
 public static class AuthEndpoints
 {
+    private const string RefreshTokenCookie = "__rt";
+
     public static void MapAuthEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/auth").WithTags("Authentication");
@@ -21,16 +23,15 @@ public static class AuthEndpoints
         .WithName("Register")
         .AllowAnonymous();
 
-        group.MapPost("/login", async (LoginRequest request, AuthService authService) =>
+        group.MapPost("/login", async (LoginRequest request, AuthService authService, HttpContext httpContext) =>
         {
             var result = await authService.LoginAsync(request);
-            if (result.IsSuccess) return Results.Ok(result.Value);
+            if (!result.IsSuccess)
+                return Results.BadRequest(new { error = "Felaktig e-postadress eller lösenord." });
 
-            // Unverified email gets a distinct code so the frontend can offer a resend link.
-            // All other failures return the same generic message (no user enumeration).
-            return result.Error!.Contains("verifiera")
-                ? Results.BadRequest(new { error = result.Error, code = "email_not_verified" })
-                : Results.BadRequest(new { error = "Felaktig e-postadress eller lösenord." });
+            SetRefreshTokenCookie(httpContext, result.Value!.RefreshToken, httpContext.RequestServices.GetRequiredService<IWebHostEnvironment>());
+
+            return Results.Ok(new AuthTokenResponse(result.Value.AccessToken, result.Value.ExpiresAt));
         })
         .WithName("Login")
         .AllowAnonymous();
@@ -44,22 +45,35 @@ public static class AuthEndpoints
         .WithName("ResendVerification")
         .AllowAnonymous();
 
-        group.MapPost("/refresh", async (RefreshRequest request, AuthService authService) =>
+        group.MapPost("/refresh", async (AuthService authService, HttpContext httpContext) =>
         {
-            var result = await authService.RefreshAsync(request);
-            return result.IsSuccess
-                ? Results.Ok(result.Value)
-                : Results.Unauthorized();
+            var refreshToken = httpContext.Request.Cookies[RefreshTokenCookie];
+            if (string.IsNullOrEmpty(refreshToken))
+                return Results.Unauthorized();
+
+            var result = await authService.RefreshAsync(refreshToken);
+            if (!result.IsSuccess)
+            {
+                ClearRefreshTokenCookie(httpContext);
+                return Results.Unauthorized();
+            }
+
+            SetRefreshTokenCookie(httpContext, result.Value!.RefreshToken, httpContext.RequestServices.GetRequiredService<IWebHostEnvironment>());
+
+            return Results.Ok(new AuthTokenResponse(result.Value.AccessToken, result.Value.ExpiresAt));
         })
         .WithName("RefreshToken")
         .AllowAnonymous();
 
-        group.MapPost("/logout", async (RefreshRequest request, AuthService authService, ClaimsPrincipal user) =>
+        group.MapPost("/logout", async (AuthService authService, ClaimsPrincipal user, HttpContext httpContext) =>
         {
             var userId = GetUserId(user);
             if (userId is null) return Results.Unauthorized();
 
-            var result = await authService.LogoutAsync(userId.Value, request.RefreshToken);
+            var refreshToken = httpContext.Request.Cookies[RefreshTokenCookie];
+            ClearRefreshTokenCookie(httpContext);
+
+            var result = await authService.LogoutAsync(userId.Value, refreshToken);
             return result.IsSuccess
                 ? Results.Ok(new { message = "Du har loggats ut." })
                 : Results.BadRequest(new { error = result.Error });
@@ -67,10 +81,12 @@ public static class AuthEndpoints
         .WithName("Logout")
         .RequireAuthorization();
 
-        group.MapPost("/logout-all", async (AuthService authService, ClaimsPrincipal user) =>
+        group.MapPost("/logout-all", async (AuthService authService, ClaimsPrincipal user, HttpContext httpContext) =>
         {
             var userId = GetUserId(user);
             if (userId is null) return Results.Unauthorized();
+
+            ClearRefreshTokenCookie(httpContext);
 
             var result = await authService.LogoutAllAsync(userId.Value);
             return result.IsSuccess
@@ -120,6 +136,23 @@ public static class AuthEndpoints
         })
         .WithName("VerifyEmail")
         .AllowAnonymous();
+    }
+
+    private static void SetRefreshTokenCookie(HttpContext ctx, string token, IWebHostEnvironment env)
+    {
+        ctx.Response.Cookies.Append(RefreshTokenCookie, token, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = !env.IsDevelopment(),
+            SameSite = env.IsDevelopment() ? SameSiteMode.Lax : SameSiteMode.None,
+            Expires = DateTimeOffset.UtcNow.AddDays(7),
+            Path = "/api/auth",
+        });
+    }
+
+    private static void ClearRefreshTokenCookie(HttpContext ctx)
+    {
+        ctx.Response.Cookies.Delete(RefreshTokenCookie, new CookieOptions { Path = "/api/auth" });
     }
 
     private static Guid? GetUserId(ClaimsPrincipal user)

--- a/backend/src/CarCheck.API/Endpoints/BillingEndpoints.cs
+++ b/backend/src/CarCheck.API/Endpoints/BillingEndpoints.cs
@@ -115,19 +115,18 @@ public static class BillingEndpoints
             using (var reader = new StreamReader(request.Body))
                 json = await reader.ReadToEndAsync();
 
-            Event stripeEvent;
             var webhookSecret = config["Stripe:WebhookSecret"];
+            if (string.IsNullOrEmpty(webhookSecret))
+            {
+                logger.LogError("Stripe:WebhookSecret is not configured — rejecting webhook");
+                return Results.StatusCode(500);
+            }
+
+            Event stripeEvent;
             try
             {
-                if (!string.IsNullOrEmpty(webhookSecret))
-                {
-                    var signature = request.Headers["Stripe-Signature"].ToString();
-                    stripeEvent = EventUtility.ConstructEvent(json, signature, webhookSecret);
-                }
-                else
-                {
-                    stripeEvent = EventUtility.ParseEvent(json);
-                }
+                var signature = request.Headers["Stripe-Signature"].ToString();
+                stripeEvent = EventUtility.ConstructEvent(json, signature, webhookSecret);
             }
             catch (Exception ex)
             {

--- a/backend/src/CarCheck.API/Program.cs
+++ b/backend/src/CarCheck.API/Program.cs
@@ -8,13 +8,18 @@ using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddOpenApi();
-builder.Services.AddInfrastructure(builder.Configuration);
-
-// JWT Authentication
+// ── JWT settings validation (VULN-009) ──────────────────────────────────────
 var jwtSettings = builder.Configuration.GetSection(JwtSettings.SectionName).Get<JwtSettings>()
     ?? new JwtSettings();
 
+if (jwtSettings.Secret.Length < 32)
+    throw new InvalidOperationException(
+        "Jwt:Secret must be at least 32 characters. Set a strong secret in environment variables.");
+
+builder.Services.AddOpenApi();
+builder.Services.AddInfrastructure(builder.Configuration, builder.Environment.IsProduction());
+
+// ── JWT Authentication ───────────────────────────────────────────────────────
 builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
@@ -28,13 +33,13 @@ builder.Services
             ValidateAudience = true,
             ValidAudience = jwtSettings.Audience,
             ValidateLifetime = true,
-            ClockSkew = TimeSpan.Zero
+            ClockSkew = TimeSpan.Zero,
         };
     });
 
 builder.Services.AddAuthorization();
 
-// CORS
+// ── CORS (VULN-007: specific methods/headers, VULN-001: credentials) ─────────
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
@@ -42,21 +47,57 @@ builder.Services.AddCors(options =>
         policy.WithOrigins(
                 builder.Configuration.GetSection("Cors:Origins").Get<string[]>()
                     ?? ["http://localhost:5173"])
-              .AllowAnyHeader()
-              .AllowAnyMethod()
+              .WithMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+              .WithHeaders(
+                  "Content-Type", "Authorization", "X-Requested-With")
               .WithExposedHeaders(
                   "X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset",
                   "X-DailyQuota-Limit", "X-DailyQuota-Remaining", "X-Subscription-Tier",
-                  "X-Request-Id");
+                  "X-Request-Id")
+              .AllowCredentials();
     });
 });
 
+// ── VULN-023: warn if Frontend:BaseUrl is not HTTPS ─────────────────────────
+var frontendBaseUrl = builder.Configuration["Frontend:BaseUrl"] ?? string.Empty;
+if (builder.Environment.IsProduction() &&
+    !frontendBaseUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+{
+    Console.Error.WriteLine(
+        $"[SECURITY WARNING] Frontend:BaseUrl is not HTTPS ({frontendBaseUrl}). " +
+        "Password-reset and verification links sent in emails may be insecure.");
+}
+
 var app = builder.Build();
 
+// ── Swagger only in development (VULN-016) ───────────────────────────────────
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
 }
+
+// ── Security headers middleware (VULN-002) ───────────────────────────────────
+app.Use(async (context, next) =>
+{
+    var headers = context.Response.Headers;
+    headers["X-Content-Type-Options"] = "nosniff";
+    headers["X-Frame-Options"] = "DENY";
+    headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+    headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()";
+
+    // HSTS — only add in production (browsers ignore it on HTTP anyway)
+    if (!context.Request.IsHttps && app.Environment.IsProduction())
+        headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains";
+    else if (context.Request.IsHttps)
+        headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains";
+
+    headers["Content-Security-Policy"] =
+        "default-src 'none'; " +
+        "frame-ancestors 'none'; " +
+        "form-action 'none'";
+
+    await next();
+});
 
 app.UseMiddleware<ExceptionHandlingMiddleware>();
 app.UseMiddleware<RequestLoggingMiddleware>();

--- a/backend/src/CarCheck.Application/Auth/AuthService.cs
+++ b/backend/src/CarCheck.Application/Auth/AuthService.cs
@@ -17,6 +17,7 @@ public class AuthService
     private readonly IEmailVerificationRepository _emailVerificationRepository;
     private readonly ICreditTransactionRepository _transactionRepository;
     private readonly IEmailService _emailService;
+    private readonly IEmailRateLimitService _emailRateLimit;
 
     public AuthService(
         IUserRepository userRepository,
@@ -27,7 +28,8 @@ public class AuthService
         IPasswordResetRepository passwordResetRepository,
         IEmailVerificationRepository emailVerificationRepository,
         ICreditTransactionRepository transactionRepository,
-        IEmailService emailService)
+        IEmailService emailService,
+        IEmailRateLimitService emailRateLimit)
     {
         _userRepository = userRepository;
         _passwordHasher = passwordHasher;
@@ -38,6 +40,7 @@ public class AuthService
         _emailVerificationRepository = emailVerificationRepository;
         _transactionRepository = transactionRepository;
         _emailService = emailService;
+        _emailRateLimit = emailRateLimit;
     }
 
     public async Task<Result<UserResponse>> RegisterAsync(RegisterRequest request, CancellationToken cancellationToken = default)
@@ -47,8 +50,9 @@ public class AuthService
         if (await _userRepository.ExistsByEmailAsync(email, cancellationToken))
             return Result<UserResponse>.Failure("E-postadressen är redan registrerad.");
 
-        if (request.Password.Length < 8)
-            return Result<UserResponse>.Failure("Lösenordet måste vara minst 8 tecken.");
+        var passwordError = ValidatePasswordStrength(request.Password);
+        if (passwordError is not null)
+            return Result<UserResponse>.Failure(passwordError);
 
         var hash = _passwordHasher.Hash(request.Password);
         var user = User.Create(request.Email, hash);
@@ -56,7 +60,6 @@ public class AuthService
         await _userRepository.AddAsync(user, cancellationToken);
         await _securityEventLogger.LogAsync(user.Id, "Registered", null, cancellationToken);
 
-        // Send verification email
         var verification = EmailVerification.Create(user.Id, TimeSpan.FromHours(24));
         await _emailVerificationRepository.AddAsync(verification, cancellationToken);
         await _emailService.SendEmailVerificationAsync(email.Value, verification.Token, cancellationToken);
@@ -86,8 +89,7 @@ public class AuthService
         user.AddCredits(1);
         await _userRepository.UpdateAsync(user, cancellationToken);
 
-        await _transactionRepository.AddAsync(
-            CreditTransaction.CreateTrial(user.Id), cancellationToken);
+        await _transactionRepository.AddAsync(CreditTransaction.CreateTrial(user.Id), cancellationToken);
 
         verification.MarkUsed();
         await _emailVerificationRepository.UpdateAsync(verification, cancellationToken);
@@ -102,17 +104,33 @@ public class AuthService
         var email = Email.Create(request.Email);
         var user = await _userRepository.GetByEmailAsync(email, cancellationToken);
 
-        if (user is null || !_passwordHasher.Verify(request.Password, user.PasswordHash))
+        // Constant-time hash comparison even for unknown users to prevent timing-based enumeration
+        if (user is null)
         {
-            if (user is not null)
-                await _securityEventLogger.LogAsync(user.Id, "LoginFailed", null, cancellationToken);
-
+            _passwordHasher.Verify(request.Password, "$2a$11$dummyhashtopreventtimingattackxx");
             return Result<AuthResponse>.Failure("Felaktig e-postadress eller lösenord.");
         }
 
-        if (!user.EmailVerified)
-            return Result<AuthResponse>.Failure("Du måste verifiera din e-postadress innan du loggar in. Kontrollera din inkorg.");
+        if (user.IsLockedOut())
+        {
+            await _securityEventLogger.LogAsync(user.Id, "LoginBlockedLockout", null, cancellationToken);
+            return Result<AuthResponse>.Failure("Kontot är tillfälligt låst på grund av för många misslyckade inloggningsförsök. Försök igen om 30 minuter.");
+        }
 
+        if (!_passwordHasher.Verify(request.Password, user.PasswordHash))
+        {
+            user.RecordFailedLogin();
+            await _userRepository.UpdateAsync(user, cancellationToken);
+            await _securityEventLogger.LogAsync(user.Id, "LoginFailed", null, cancellationToken);
+            return Result<AuthResponse>.Failure("Felaktig e-postadress eller lösenord.");
+        }
+
+        // Return generic message for unverified email — avoids enumeration via different error codes
+        if (!user.EmailVerified)
+            return Result<AuthResponse>.Failure("Felaktig e-postadress eller lösenord.");
+
+        user.RecordSuccessfulLogin();
+        await _userRepository.UpdateAsync(user, cancellationToken);
 
         var accessToken = _tokenService.GenerateAccessToken(user);
         var refreshToken = _tokenService.GenerateRefreshToken();
@@ -132,9 +150,9 @@ public class AuthService
         return Result<AuthResponse>.Success(new AuthResponse(accessToken, refreshToken, DateTime.UtcNow.AddMinutes(15)));
     }
 
-    public async Task<Result<AuthResponse>> RefreshAsync(RefreshRequest request, CancellationToken cancellationToken = default)
+    public async Task<Result<AuthResponse>> RefreshAsync(string refreshToken, CancellationToken cancellationToken = default)
     {
-        var existing = await _refreshTokenRepository.GetByTokenAsync(request.RefreshToken, cancellationToken);
+        var existing = await _refreshTokenRepository.GetByTokenAsync(refreshToken, cancellationToken);
 
         if (existing is null || existing.Revoked || existing.ExpiresAt < DateTime.UtcNow)
             return Result<AuthResponse>.Failure("Ogiltig eller utgången session. Logga in igen.");
@@ -159,12 +177,17 @@ public class AuthService
             CreatedAt = DateTime.UtcNow
         }, cancellationToken);
 
+        // Log rotation event (VULN-019)
+        await _securityEventLogger.LogAsync(user.Id, "TokenRefreshed", null, cancellationToken);
+
         return Result<AuthResponse>.Success(new AuthResponse(newAccessToken, newRefreshToken, DateTime.UtcNow.AddMinutes(15)));
     }
 
-    public async Task<Result<bool>> LogoutAsync(Guid userId, string refreshToken, CancellationToken cancellationToken = default)
+    public async Task<Result<bool>> LogoutAsync(Guid userId, string? refreshToken, CancellationToken cancellationToken = default)
     {
-        await _refreshTokenRepository.RevokeAsync(refreshToken, cancellationToken);
+        if (!string.IsNullOrEmpty(refreshToken))
+            await _refreshTokenRepository.RevokeAsync(refreshToken, cancellationToken);
+
         await _securityEventLogger.LogAsync(userId, "Logout", null, cancellationToken);
 
         return Result<bool>.Success(true);
@@ -180,6 +203,9 @@ public class AuthService
 
     public async Task ResendVerificationAsync(string email, CancellationToken cancellationToken = default)
     {
+        if (_emailRateLimit.IsRateLimited(email, "resend"))
+            return;
+
         var emailVo = Email.Create(email);
         var user = await _userRepository.GetByEmailAsync(emailVo, cancellationToken);
 
@@ -189,10 +215,15 @@ public class AuthService
         var verification = EmailVerification.Create(user.Id, TimeSpan.FromHours(24));
         await _emailVerificationRepository.AddAsync(verification, cancellationToken);
         await _emailService.SendEmailVerificationAsync(emailVo.Value, verification.Token, cancellationToken);
+
+        _emailRateLimit.IncrementCount(email, "resend");
     }
 
     public async Task<Result<bool>> ForgotPasswordAsync(PasswordResetRequest request, CancellationToken cancellationToken = default)
     {
+        if (_emailRateLimit.IsRateLimited(request.Email, "reset"))
+            return Result<bool>.Success(true); // Always return success to avoid enumeration
+
         var email = Email.Create(request.Email);
         var user = await _userRepository.GetByEmailAsync(email, cancellationToken);
 
@@ -207,13 +238,16 @@ public class AuthService
 
         await _securityEventLogger.LogAsync(user.Id, "PasswordResetRequested", null, cancellationToken);
 
+        _emailRateLimit.IncrementCount(request.Email, "reset");
+
         return Result<bool>.Success(true);
     }
 
     public async Task<Result<bool>> ResetPasswordAsync(PasswordResetConfirmRequest request, CancellationToken cancellationToken = default)
     {
-        if (request.NewPassword.Length < 8)
-            return Result<bool>.Failure("Lösenordet måste vara minst 8 tecken.");
+        var passwordError = ValidatePasswordStrength(request.NewPassword);
+        if (passwordError is not null)
+            return Result<bool>.Failure(passwordError);
 
         var reset = await _passwordResetRepository.GetByTokenAsync(request.Token, cancellationToken);
 
@@ -245,17 +279,28 @@ public class AuthService
         if (!_passwordHasher.Verify(request.CurrentPassword, user.PasswordHash))
             return Result<bool>.Failure("Nuvarande lösenord är felaktigt.");
 
-        if (request.NewPassword.Length < 8)
-            return Result<bool>.Failure("Lösenordet måste vara minst 8 tecken.");
+        var passwordError = ValidatePasswordStrength(request.NewPassword);
+        if (passwordError is not null)
+            return Result<bool>.Failure(passwordError);
 
         user.ChangePassword(_passwordHasher.Hash(request.NewPassword));
         await _userRepository.UpdateAsync(user, cancellationToken);
 
-        // Invalidate all refresh tokens on password change
         await _refreshTokenRepository.RevokeAllForUserAsync(userId, cancellationToken);
         await _securityEventLogger.LogAsync(userId, "PasswordChanged", null, cancellationToken);
 
         return Result<bool>.Success(true);
+    }
+
+    private static string? ValidatePasswordStrength(string password)
+    {
+        if (password.Length < 12)
+            return "Lösenordet måste vara minst 12 tecken.";
+        if (!password.Any(char.IsUpper))
+            return "Lösenordet måste innehålla minst en stor bokstav.";
+        if (!password.Any(char.IsDigit))
+            return "Lösenordet måste innehålla minst en siffra.";
+        return null;
     }
 }
 

--- a/backend/src/CarCheck.Application/Auth/DTOs/AuthDTOs.cs
+++ b/backend/src/CarCheck.Application/Auth/DTOs/AuthDTOs.cs
@@ -16,4 +16,7 @@ public record ResendVerificationRequest(string Email);
 
 public record AuthResponse(string AccessToken, string RefreshToken, DateTime ExpiresAt);
 
+// HTTP response — never includes the refresh token (sent as HttpOnly cookie instead)
+public record AuthTokenResponse(string AccessToken, DateTime ExpiresAt);
+
 public record UserResponse(Guid Id, string Email, bool EmailVerified, bool TwoFactorEnabled);

--- a/backend/src/CarCheck.Application/Interfaces/IEmailRateLimitService.cs
+++ b/backend/src/CarCheck.Application/Interfaces/IEmailRateLimitService.cs
@@ -1,0 +1,10 @@
+namespace CarCheck.Application.Interfaces;
+
+/// <summary>
+/// Prevents email flooding by rate-limiting per-address per-action (max 3 per hour).
+/// </summary>
+public interface IEmailRateLimitService
+{
+    bool IsRateLimited(string email, string action);
+    void IncrementCount(string email, string action);
+}

--- a/backend/src/CarCheck.Domain/Entities/EmailVerification.cs
+++ b/backend/src/CarCheck.Domain/Entities/EmailVerification.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 namespace CarCheck.Domain.Entities;
 
 public class EmailVerification
@@ -19,7 +21,7 @@ public class EmailVerification
         {
             Id = Guid.NewGuid(),
             UserId = userId,
-            Token = Convert.ToBase64String(Guid.NewGuid().ToByteArray()),
+            Token = Convert.ToHexString(RandomNumberGenerator.GetBytes(32)),
             ExpiresAt = DateTime.UtcNow.Add(expiration),
             Used = false
         };

--- a/backend/src/CarCheck.Domain/Entities/PasswordReset.cs
+++ b/backend/src/CarCheck.Domain/Entities/PasswordReset.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 namespace CarCheck.Domain.Entities;
 
 public class PasswordReset
@@ -19,7 +21,7 @@ public class PasswordReset
         {
             Id = Guid.NewGuid(),
             UserId = userId,
-            Token = Convert.ToBase64String(Guid.NewGuid().ToByteArray()),
+            Token = Convert.ToHexString(RandomNumberGenerator.GetBytes(32)),
             ExpiresAt = DateTime.UtcNow.Add(expiration),
             Used = false
         };

--- a/backend/src/CarCheck.Domain/Entities/User.cs
+++ b/backend/src/CarCheck.Domain/Entities/User.cs
@@ -4,6 +4,9 @@ namespace CarCheck.Domain.Entities;
 
 public class User
 {
+    private const int MaxFailedAttempts = 5;
+    private static readonly TimeSpan LockoutDuration = TimeSpan.FromMinutes(30);
+
     public Guid Id { get; private set; }
     public Email Email { get; private set; } = null!;
     public string PasswordHash { get; private set; } = string.Empty;
@@ -11,6 +14,8 @@ public class User
     public bool TwoFactorEnabled { get; private set; }
     public DateTime CreatedAt { get; private set; }
     public int Credits { get; private set; }
+    public int FailedLoginAttempts { get; private set; }
+    public DateTime? LockoutUntil { get; private set; }
 
     private User() { }
 
@@ -26,8 +31,25 @@ public class User
             PasswordHash = passwordHash,
             EmailVerified = false,
             TwoFactorEnabled = false,
-            CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow,
+            FailedLoginAttempts = 0,
         };
+    }
+
+    public bool IsLockedOut() =>
+        LockoutUntil.HasValue && LockoutUntil.Value > DateTime.UtcNow;
+
+    public void RecordFailedLogin()
+    {
+        FailedLoginAttempts++;
+        if (FailedLoginAttempts >= MaxFailedAttempts)
+            LockoutUntil = DateTime.UtcNow.Add(LockoutDuration);
+    }
+
+    public void RecordSuccessfulLogin()
+    {
+        FailedLoginAttempts = 0;
+        LockoutUntil = null;
     }
 
     public void VerifyEmail() => EmailVerified = true;

--- a/backend/src/CarCheck.Infrastructure/DependencyInjection.cs
+++ b/backend/src/CarCheck.Infrastructure/DependencyInjection.cs
@@ -20,7 +20,10 @@ namespace CarCheck.Infrastructure;
 
 public static class DependencyInjection
 {
-    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddInfrastructure(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        bool isProduction = false)
     {
         var connectionString = configuration.GetConnectionString("DefaultConnection")
             ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
@@ -47,7 +50,7 @@ public static class DependencyInjection
         services.AddScoped<ISecurityEventLogger, SecurityEventLogger>();
         services.AddScoped<AuthService>();
 
-        // Caching
+        // Caching (also used by AuthService for email rate limiting)
         services.AddMemoryCache();
         services.AddSingleton<ICacheService, InMemoryCacheService>();
 
@@ -62,8 +65,14 @@ public static class DependencyInjection
         services.AddScoped<SearchHistoryService>();
         services.AddScoped<FavoriteService>();
 
-        // Rate limiting & CAPTCHA
+        // Rate limiting
         services.AddSingleton<IRateLimitService, InMemoryRateLimitService>();
+        services.AddSingleton<IEmailRateLimitService, InMemoryEmailRateLimitService>();
+
+        // CAPTCHA — MockCaptchaService must never be used in production (VULN-003)
+        if (isProduction)
+            throw new InvalidOperationException(
+                "MockCaptchaService is not allowed in production. Register a real ICaptchaService implementation.");
         services.AddScoped<ICaptchaService, MockCaptchaService>();
 
         // Billing & Subscriptions
@@ -78,14 +87,13 @@ public static class DependencyInjection
         // GDPR
         services.AddScoped<GdprService>();
 
-        // Email (Resend)
-        var resendApiKey = configuration["Resend:ApiKey"]
-            ?? throw new InvalidOperationException("Resend:ApiKey is not configured.");
+        // Email (Resend) — auth header injected via DelegatingHandler (VULN-015)
+        services.AddTransient<ResendAuthHandler>();
         services.AddHttpClient<IEmailService, ResendEmailService>(client =>
         {
             client.BaseAddress = new Uri("https://api.resend.com/");
-            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {resendApiKey}");
-        });
+        })
+        .AddHttpMessageHandler<ResendAuthHandler>();
 
         return services;
     }

--- a/backend/src/CarCheck.Infrastructure/External/ResendAuthHandler.cs
+++ b/backend/src/CarCheck.Infrastructure/External/ResendAuthHandler.cs
@@ -1,0 +1,25 @@
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Configuration;
+
+namespace CarCheck.Infrastructure.External;
+
+/// <summary>
+/// DelegatingHandler that attaches the Resend API key to every outbound request.
+/// Keeping the credential out of DefaultRequestHeaders avoids accidental mutation.
+/// </summary>
+public class ResendAuthHandler : DelegatingHandler
+{
+    private readonly string _apiKey;
+
+    public ResendAuthHandler(IConfiguration configuration)
+    {
+        _apiKey = configuration["Resend:ApiKey"]
+            ?? throw new InvalidOperationException("Resend:ApiKey is not configured.");
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/backend/src/CarCheck.Infrastructure/External/ResendEmailService.cs
+++ b/backend/src/CarCheck.Infrastructure/External/ResendEmailService.cs
@@ -11,6 +11,7 @@ public class ResendEmailService : IEmailService
     private readonly ILogger<ResendEmailService> _logger;
     private readonly string _frontendBaseUrl;
 
+    // Authorization header is injected by ResendAuthHandler — no API key stored here.
     public ResendEmailService(HttpClient http, IConfiguration configuration, ILogger<ResendEmailService> logger)
     {
         _http = http;

--- a/backend/src/CarCheck.Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/backend/src/CarCheck.Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -44,5 +44,13 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
         builder.Property(u => u.Credits)
             .HasColumnName("credits")
             .HasDefaultValue(0);
+
+        builder.Property(u => u.FailedLoginAttempts)
+            .HasColumnName("failed_login_attempts")
+            .HasDefaultValue(0);
+
+        builder.Property(u => u.LockoutUntil)
+            .HasColumnName("lockout_until")
+            .IsRequired(false);
     }
 }

--- a/backend/src/CarCheck.Infrastructure/Persistence/Migrations/20260314000000_AddUserLockout.cs
+++ b/backend/src/CarCheck.Infrastructure/Persistence/Migrations/20260314000000_AddUserLockout.cs
@@ -1,0 +1,40 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CarCheck.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserLockout : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "failed_login_attempts",
+                table: "users",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "lockout_until",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "failed_login_attempts",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "lockout_until",
+                table: "users");
+        }
+    }
+}

--- a/backend/src/CarCheck.Infrastructure/Persistence/Migrations/CarCheckDbContextModelSnapshot.cs
+++ b/backend/src/CarCheck.Infrastructure/Persistence/Migrations/CarCheckDbContextModelSnapshot.cs
@@ -367,6 +367,16 @@ namespace CarCheck.Infrastructure.Persistence.Migrations
                         .HasDefaultValue(0)
                         .HasColumnName("credits");
 
+                    b.Property<int>("FailedLoginAttempts")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer")
+                        .HasDefaultValue(0)
+                        .HasColumnName("failed_login_attempts");
+
+                    b.Property<DateTime?>("LockoutUntil")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("lockout_until");
+
                     b.HasKey("Id");
 
                     b.HasIndex("Email")

--- a/backend/src/CarCheck.Infrastructure/Persistence/Repositories/DeletionFeedbackRepository.cs
+++ b/backend/src/CarCheck.Infrastructure/Persistence/Repositories/DeletionFeedbackRepository.cs
@@ -15,9 +15,8 @@ public class DeletionFeedbackRepository : IDeletionFeedbackRepository
 
     public async Task AddAsync(string reason, CancellationToken cancellationToken = default)
     {
-        await _context.Database.ExecuteSqlRawAsync(
-            "INSERT INTO deletion_feedback (reason) VALUES ({0})",
-            new object[] { reason },
+        await _context.Database.ExecuteSqlInterpolatedAsync(
+            $"INSERT INTO deletion_feedback (reason) VALUES ({reason})",
             cancellationToken);
     }
 }

--- a/backend/src/CarCheck.Infrastructure/RateLimiting/InMemoryEmailRateLimitService.cs
+++ b/backend/src/CarCheck.Infrastructure/RateLimiting/InMemoryEmailRateLimitService.cs
@@ -1,0 +1,32 @@
+using CarCheck.Application.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace CarCheck.Infrastructure.RateLimiting;
+
+public class InMemoryEmailRateLimitService : IEmailRateLimitService
+{
+    private readonly IMemoryCache _cache;
+    private const int Max = 3;
+    private static readonly TimeSpan Window = TimeSpan.FromHours(1);
+
+    public InMemoryEmailRateLimitService(IMemoryCache cache)
+    {
+        _cache = cache;
+    }
+
+    public bool IsRateLimited(string email, string action)
+    {
+        var key = BuildKey(email, action);
+        return _cache.TryGetValue(key, out int count) && count >= Max;
+    }
+
+    public void IncrementCount(string email, string action)
+    {
+        var key = BuildKey(email, action);
+        _cache.TryGetValue(key, out int count);
+        _cache.Set(key, count + 1, Window);
+    }
+
+    private static string BuildKey(string email, string action) =>
+        $"email_rl:{action}:{email.ToLowerInvariant()}";
+}

--- a/backend/tests/CarCheck.Application.Tests/Auth/AuthServiceTests.cs
+++ b/backend/tests/CarCheck.Application.Tests/Auth/AuthServiceTests.cs
@@ -19,6 +19,7 @@ public class AuthServiceTests
     private readonly IEmailVerificationRepository _emailVerificationRepository;
     private readonly ICreditTransactionRepository _transactionRepository;
     private readonly IEmailService _emailService;
+    private readonly IEmailRateLimitService _emailRateLimit;
     private readonly AuthService _sut;
 
     public AuthServiceTests()
@@ -32,6 +33,7 @@ public class AuthServiceTests
         _emailVerificationRepository = Substitute.For<IEmailVerificationRepository>();
         _transactionRepository = Substitute.For<ICreditTransactionRepository>();
         _emailService = Substitute.For<IEmailService>();
+        _emailRateLimit = Substitute.For<IEmailRateLimitService>();
 
         _sut = new AuthService(
             _userRepository,
@@ -42,7 +44,8 @@ public class AuthServiceTests
             _passwordResetRepository,
             _emailVerificationRepository,
             _transactionRepository,
-            _emailService);
+            _emailService,
+            _emailRateLimit);
     }
 
     // ===== Register =====
@@ -51,9 +54,9 @@ public class AuthServiceTests
     public async Task Register_WithValidData_ShouldReturnSuccess()
     {
         _userRepository.ExistsByEmailAsync(Arg.Any<Email>()).Returns(false);
-        _passwordHasher.Hash("Password123!").Returns("hashed");
+        _passwordHasher.Hash("Password123!Long").Returns("hashed");
 
-        var result = await _sut.RegisterAsync(new RegisterRequest("user@test.com", "Password123!"));
+        var result = await _sut.RegisterAsync(new RegisterRequest("user@test.com", "Password123!Long"));
 
         Assert.True(result.IsSuccess);
         Assert.Equal("user@test.com", result.Value!.Email);
@@ -66,10 +69,10 @@ public class AuthServiceTests
     {
         _userRepository.ExistsByEmailAsync(Arg.Any<Email>()).Returns(true);
 
-        var result = await _sut.RegisterAsync(new RegisterRequest("existing@test.com", "Password123!"));
+        var result = await _sut.RegisterAsync(new RegisterRequest("existing@test.com", "Password123!Long"));
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("Email is already registered.", result.Error);
+        Assert.Equal("E-postadressen är redan registrerad.", result.Error);
     }
 
     [Fact]
@@ -80,7 +83,29 @@ public class AuthServiceTests
         var result = await _sut.RegisterAsync(new RegisterRequest("user@test.com", "short"));
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("Password must be at least 8 characters.", result.Error);
+        Assert.Equal("Lösenordet måste vara minst 12 tecken.", result.Error);
+    }
+
+    [Fact]
+    public async Task Register_WithNoUppercase_ShouldReturnFailure()
+    {
+        _userRepository.ExistsByEmailAsync(Arg.Any<Email>()).Returns(false);
+
+        var result = await _sut.RegisterAsync(new RegisterRequest("user@test.com", "alllowercase123!"));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Lösenordet måste innehålla minst en stor bokstav.", result.Error);
+    }
+
+    [Fact]
+    public async Task Register_WithNoDigit_ShouldReturnFailure()
+    {
+        _userRepository.ExistsByEmailAsync(Arg.Any<Email>()).Returns(false);
+
+        var result = await _sut.RegisterAsync(new RegisterRequest("user@test.com", "NoDigitsHereAtAll!"));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Lösenordet måste innehålla minst en siffra.", result.Error);
     }
 
     // ===== Login =====
@@ -89,12 +114,13 @@ public class AuthServiceTests
     public async Task Login_WithValidCredentials_ShouldReturnTokens()
     {
         var user = User.Create("user@test.com", "hashed");
+        user.VerifyEmail();
         _userRepository.GetByEmailAsync(Arg.Any<Email>()).Returns(user);
-        _passwordHasher.Verify("Password123!", "hashed").Returns(true);
+        _passwordHasher.Verify("Password123!Long", "hashed").Returns(true);
         _tokenService.GenerateAccessToken(user).Returns("access_token");
         _tokenService.GenerateRefreshToken().Returns("refresh_token");
 
-        var result = await _sut.LoginAsync(new LoginRequest("user@test.com", "Password123!"));
+        var result = await _sut.LoginAsync(new LoginRequest("user@test.com", "Password123!Long"));
 
         Assert.True(result.IsSuccess);
         Assert.Equal("access_token", result.Value!.AccessToken);
@@ -112,7 +138,7 @@ public class AuthServiceTests
         var result = await _sut.LoginAsync(new LoginRequest("user@test.com", "wrong"));
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("Invalid email or password.", result.Error);
+        Assert.Equal("Felaktig e-postadress eller lösenord.", result.Error);
         await _securityEventLogger.Received(1).LogAsync(user.Id, "LoginFailed", null, Arg.Any<CancellationToken>());
     }
 
@@ -120,11 +146,28 @@ public class AuthServiceTests
     public async Task Login_WithNonExistentEmail_ShouldReturnFailure()
     {
         _userRepository.GetByEmailAsync(Arg.Any<Email>()).Returns((User?)null);
+        _passwordHasher.Verify(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
 
-        var result = await _sut.LoginAsync(new LoginRequest("nonexistent@test.com", "Password123!"));
+        var result = await _sut.LoginAsync(new LoginRequest("nonexistent@test.com", "Password123!Long"));
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("Invalid email or password.", result.Error);
+        Assert.Equal("Felaktig e-postadress eller lösenord.", result.Error);
+    }
+
+    [Fact]
+    public async Task Login_WithLockedAccount_ShouldReturnFailure()
+    {
+        var user = User.Create("user@test.com", "hashed");
+        // Record 5 failures to trigger lockout
+        for (int i = 0; i < 5; i++) user.RecordFailedLogin();
+
+        _userRepository.GetByEmailAsync(Arg.Any<Email>()).Returns(user);
+
+        var result = await _sut.LoginAsync(new LoginRequest("user@test.com", "anypassword"));
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("låst", result.Error);
+        await _securityEventLogger.Received(1).LogAsync(user.Id, "LoginBlockedLockout", null, Arg.Any<CancellationToken>());
     }
 
     // ===== Refresh =====
@@ -148,13 +191,14 @@ public class AuthServiceTests
         _tokenService.GenerateAccessToken(user).Returns("new_access");
         _tokenService.GenerateRefreshToken().Returns("new_refresh");
 
-        var result = await _sut.RefreshAsync(new RefreshRequest("old_refresh"));
+        var result = await _sut.RefreshAsync("old_refresh");
 
         Assert.True(result.IsSuccess);
         Assert.Equal("new_access", result.Value!.AccessToken);
         Assert.Equal("new_refresh", result.Value.RefreshToken);
         await _refreshTokenRepository.Received(1).RevokeAsync("old_refresh", Arg.Any<CancellationToken>());
         await _refreshTokenRepository.Received(1).AddAsync(Arg.Any<RefreshTokenEntry>(), Arg.Any<CancellationToken>());
+        await _securityEventLogger.Received(1).LogAsync(user.Id, "TokenRefreshed", null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -168,7 +212,7 @@ public class AuthServiceTests
         };
         _refreshTokenRepository.GetByTokenAsync("revoked_token").Returns(entry);
 
-        var result = await _sut.RefreshAsync(new RefreshRequest("revoked_token"));
+        var result = await _sut.RefreshAsync("revoked_token");
 
         Assert.False(result.IsSuccess);
     }
@@ -184,7 +228,7 @@ public class AuthServiceTests
         };
         _refreshTokenRepository.GetByTokenAsync("expired_token").Returns(entry);
 
-        var result = await _sut.RefreshAsync(new RefreshRequest("expired_token"));
+        var result = await _sut.RefreshAsync("expired_token");
 
         Assert.False(result.IsSuccess);
     }
@@ -223,9 +267,9 @@ public class AuthServiceTests
         var user = User.Create("user@test.com", "old_hash");
         _userRepository.GetByIdAsync(user.Id).Returns(user);
         _passwordHasher.Verify("OldPass123!", "old_hash").Returns(true);
-        _passwordHasher.Hash("NewPass123!").Returns("new_hash");
+        _passwordHasher.Hash("NewPass123!Long").Returns("new_hash");
 
-        var result = await _sut.ChangePasswordAsync(user.Id, new ChangePasswordRequest("OldPass123!", "NewPass123!"));
+        var result = await _sut.ChangePasswordAsync(user.Id, new ChangePasswordRequest("OldPass123!", "NewPass123!Long"));
 
         Assert.True(result.IsSuccess);
         await _userRepository.Received(1).UpdateAsync(user, Arg.Any<CancellationToken>());
@@ -240,10 +284,10 @@ public class AuthServiceTests
         _userRepository.GetByIdAsync(user.Id).Returns(user);
         _passwordHasher.Verify("wrong", "old_hash").Returns(false);
 
-        var result = await _sut.ChangePasswordAsync(user.Id, new ChangePasswordRequest("wrong", "NewPass123!"));
+        var result = await _sut.ChangePasswordAsync(user.Id, new ChangePasswordRequest("wrong", "NewPass123!Long"));
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("Current password is incorrect.", result.Error);
+        Assert.Equal("Nuvarande lösenord är felaktigt.", result.Error);
     }
 
     [Fact]
@@ -256,7 +300,7 @@ public class AuthServiceTests
         var result = await _sut.ChangePasswordAsync(user.Id, new ChangePasswordRequest("OldPass123!", "short"));
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("New password must be at least 8 characters.", result.Error);
+        Assert.Equal("Lösenordet måste vara minst 12 tecken.", result.Error);
     }
 
     [Fact]
@@ -265,9 +309,9 @@ public class AuthServiceTests
         var userId = Guid.NewGuid();
         _userRepository.GetByIdAsync(userId).Returns((User?)null);
 
-        var result = await _sut.ChangePasswordAsync(userId, new ChangePasswordRequest("old", "NewPass123!"));
+        var result = await _sut.ChangePasswordAsync(userId, new ChangePasswordRequest("old", "NewPass123!Long"));
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("User not found.", result.Error);
+        Assert.Equal("Användare hittades inte.", result.Error);
     }
 }

--- a/backend/tests/CarCheck.Application.Tests/Billing/SubscriptionServiceTests.cs
+++ b/backend/tests/CarCheck.Application.Tests/Billing/SubscriptionServiceTests.cs
@@ -15,6 +15,7 @@ public class SubscriptionServiceTests
     private readonly IBillingProvider _billingProvider;
     private readonly ISecurityEventLogger _securityEventLogger;
     private readonly ICreditTransactionRepository _transactionRepository;
+    private readonly IEmailService _emailService;
     private readonly SubscriptionService _sut;
 
     public SubscriptionServiceTests()
@@ -24,13 +25,15 @@ public class SubscriptionServiceTests
         _billingProvider = Substitute.For<IBillingProvider>();
         _securityEventLogger = Substitute.For<ISecurityEventLogger>();
         _transactionRepository = Substitute.For<ICreditTransactionRepository>();
+        _emailService = Substitute.For<IEmailService>();
 
         _sut = new SubscriptionService(
             _subscriptionRepository,
             _userRepository,
             _billingProvider,
             _securityEventLogger,
-            _transactionRepository);
+            _transactionRepository,
+            _emailService);
     }
 
     // ===== Get Current Subscription =====
@@ -45,8 +48,8 @@ public class SubscriptionServiceTests
 
         Assert.True(result.IsSuccess);
         Assert.Equal(SubscriptionTier.Free, result.Value!.Tier);
-        Assert.Equal("Free", result.Value.TierName);
-        Assert.Equal(5, result.Value.Limits.DailySearches);
+        Assert.Equal("Gratis", result.Value.TierName);
+        Assert.Equal(3, result.Value.Limits.DailySearches);
     }
 
     [Fact]
@@ -60,7 +63,7 @@ public class SubscriptionServiceTests
 
         Assert.True(result.IsSuccess);
         Assert.Equal(SubscriptionTier.Pro, result.Value!.Tier);
-        Assert.Equal(50, result.Value.Limits.DailySearches);
+        Assert.True(result.Value.Limits.DailySearches > 1000);
         Assert.True(result.Value.Limits.AnalysisIncluded);
     }
 
@@ -74,7 +77,7 @@ public class SubscriptionServiceTests
         var result = await _sut.CreateCheckoutAsync(userId, new SubscribeRequest(SubscriptionTier.Free));
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("Cannot purchase a free subscription.", result.Error);
+        Assert.Equal("Det går inte att köpa ett gratisabonnemang.", result.Error);
     }
 
     [Fact]
@@ -86,23 +89,25 @@ public class SubscriptionServiceTests
         var result = await _sut.CreateCheckoutAsync(userId, new SubscribeRequest(SubscriptionTier.Pro));
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("User not found.", result.Error);
+        Assert.Equal("Användare hittades inte.", result.Error);
     }
 
     [Fact]
-    public async Task CreateCheckout_AlreadyHasHigherTier_ReturnsFailure()
+    public async Task CreateCheckout_WithExistingSubscription_StillCreatesCheckout()
     {
         var userId = Guid.NewGuid();
         var user = User.Create("user@test.com", "hashed");
-        var existingSub = Subscription.Create(userId, SubscriptionTier.Premium);
+        var existingSub = Subscription.Create(userId, SubscriptionTier.Pro);
 
         _userRepository.GetByIdAsync(userId).Returns(user);
         _subscriptionRepository.GetActiveByUserIdAsync(userId).Returns(existingSub);
+        _billingProvider.CreateCheckoutSessionAsync(userId, SubscriptionTier.Pro, Arg.Any<CancellationToken>())
+            .Returns(new CreateCheckoutResult("sess_999", "https://checkout.example.com/sess_999"));
 
         var result = await _sut.CreateCheckoutAsync(userId, new SubscribeRequest(SubscriptionTier.Pro));
 
-        Assert.False(result.IsSuccess);
-        Assert.Contains("Premium", result.Error);
+        Assert.True(result.IsSuccess);
+        await _billingProvider.Received(1).CreateCheckoutSessionAsync(userId, SubscriptionTier.Pro, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -153,7 +158,7 @@ public class SubscriptionServiceTests
         var result = await _sut.CancelSubscriptionAsync(userId);
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("No active subscription found.", result.Error);
+        Assert.Equal("Inget aktivt abonnemang hittades.", result.Error);
     }
 
     [Fact]
@@ -174,13 +179,12 @@ public class SubscriptionServiceTests
     // ===== Get Available Tiers =====
 
     [Fact]
-    public void GetAvailableTiers_ReturnsAllThreeTiers()
+    public void GetAvailableTiers_ReturnsTwoTiers()
     {
         var tiers = _sut.GetAvailableTiers();
 
-        Assert.Equal(3, tiers.Count);
+        Assert.Equal(2, tiers.Count);
         Assert.Contains(tiers, t => t.Tier == SubscriptionTier.Free && t.PricePerMonthSek == 0);
-        Assert.Contains(tiers, t => t.Tier == SubscriptionTier.Pro && t.PricePerMonthSek == 99);
-        Assert.Contains(tiers, t => t.Tier == SubscriptionTier.Premium && t.PricePerMonthSek == 249);
+        Assert.Contains(tiers, t => t.Tier == SubscriptionTier.Pro && t.PricePerMonthSek == 499);
     }
 }

--- a/backend/tests/CarCheck.Application.Tests/Billing/TierConfigurationTests.cs
+++ b/backend/tests/CarCheck.Application.Tests/Billing/TierConfigurationTests.cs
@@ -10,11 +10,11 @@ public class TierConfigurationTests
     {
         var limits = TierConfiguration.GetLimits(SubscriptionTier.Free);
 
-        Assert.Equal(5, limits.DailySearches);
-        Assert.Equal(50, limits.MonthlySearches);
-        Assert.False(limits.AnalysisIncluded);
+        Assert.Equal(3, limits.DailySearches);
+        Assert.Equal(90, limits.MonthlySearches);
+        Assert.True(limits.AnalysisIncluded);
         Assert.Equal(0m, limits.PricePerMonthSek);
-        Assert.Equal("Free", limits.Name);
+        Assert.Equal("Gratis", limits.Name);
     }
 
     [Fact]
@@ -22,10 +22,10 @@ public class TierConfigurationTests
     {
         var limits = TierConfiguration.GetLimits(SubscriptionTier.Pro);
 
-        Assert.Equal(50, limits.DailySearches);
-        Assert.Equal(500, limits.MonthlySearches);
+        Assert.Equal(int.MaxValue, limits.DailySearches);
+        Assert.Equal(int.MaxValue, limits.MonthlySearches);
         Assert.True(limits.AnalysisIncluded);
-        Assert.Equal(99m, limits.PricePerMonthSek);
+        Assert.Equal(499m, limits.PricePerMonthSek);
     }
 
     [Fact]
@@ -36,6 +36,6 @@ public class TierConfigurationTests
         Assert.Equal(int.MaxValue, limits.DailySearches);
         Assert.Equal(int.MaxValue, limits.MonthlySearches);
         Assert.True(limits.AnalysisIncluded);
-        Assert.Equal(249m, limits.PricePerMonthSek);
+        Assert.Equal(499m, limits.PricePerMonthSek);
     }
 }

--- a/backend/tests/CarCheck.Application.Tests/Cars/CarSearchServiceTests.cs
+++ b/backend/tests/CarCheck.Application.Tests/Cars/CarSearchServiceTests.cs
@@ -115,7 +115,7 @@ public class CarSearchServiceTests
         var result = await _sut.SearchByRegistrationAsync(userId, new CarSearchRequest("UNKNOWN"));
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("No vehicle found with this registration number.", result.Error);
+        Assert.Equal("Inget fordon hittades med det registreringsnumret.", result.Error);
     }
 
     [Fact]
@@ -167,7 +167,7 @@ public class CarSearchServiceTests
         var result = await _sut.AnalyzeCarAsync(carId);
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("Car not found.", result.Error);
+        Assert.Equal("Bilen hittades inte.", result.Error);
     }
 
     [Fact]
@@ -184,7 +184,7 @@ public class CarSearchServiceTests
         var result = await _sut.AnalyzeCarAsync(carId);
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("Unable to fetch vehicle data for analysis.", result.Error);
+        Assert.Equal("Kunde inte hämta fordonsdata för analys.", result.Error);
     }
 
     [Fact]

--- a/backend/tests/CarCheck.Application.Tests/Favorites/FavoriteServiceTests.cs
+++ b/backend/tests/CarCheck.Application.Tests/Favorites/FavoriteServiceTests.cs
@@ -88,7 +88,7 @@ public class FavoriteServiceTests
         var result = await _sut.AddFavoriteAsync(userId, new AddFavoriteRequest(carId));
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("Car not found.", result.Error);
+        Assert.Equal("Bilen hittades inte.", result.Error);
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class FavoriteServiceTests
         var result = await _sut.AddFavoriteAsync(userId, new AddFavoriteRequest(car.Id));
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("Car is already in favorites.", result.Error);
+        Assert.Equal("Bilen finns redan i favoriter.", result.Error);
     }
 
     // ===== Remove Favorite =====
@@ -137,7 +137,7 @@ public class FavoriteServiceTests
         var result = await _sut.RemoveFavoriteAsync(userId, carId);
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("Favorite not found.", result.Error);
+        Assert.Equal("Favoriten hittades inte.", result.Error);
     }
 
     // ===== Check Favorite =====

--- a/backend/tests/CarCheck.Application.Tests/Gdpr/GdprServiceTests.cs
+++ b/backend/tests/CarCheck.Application.Tests/Gdpr/GdprServiceTests.cs
@@ -15,6 +15,8 @@ public class GdprServiceTests
     private readonly ISubscriptionRepository _subscriptionRepository;
     private readonly IRefreshTokenRepository _refreshTokenRepository;
     private readonly ISecurityEventLogger _securityEventLogger;
+    private readonly IPasswordHasher _passwordHasher;
+    private readonly IDeletionFeedbackRepository _deletionFeedbackRepository;
     private readonly GdprService _sut;
 
     public GdprServiceTests()
@@ -25,13 +27,18 @@ public class GdprServiceTests
         _subscriptionRepository = Substitute.For<ISubscriptionRepository>();
         _refreshTokenRepository = Substitute.For<IRefreshTokenRepository>();
         _securityEventLogger = Substitute.For<ISecurityEventLogger>();
+        _passwordHasher = Substitute.For<IPasswordHasher>();
+        _deletionFeedbackRepository = Substitute.For<IDeletionFeedbackRepository>();
+
         _sut = new GdprService(
             _userRepository,
             _searchHistoryRepository,
             _favoriteRepository,
             _subscriptionRepository,
             _refreshTokenRepository,
-            _securityEventLogger);
+            _securityEventLogger,
+            _passwordHasher,
+            _deletionFeedbackRepository);
     }
 
     // ===== Export User Data =====
@@ -78,7 +85,7 @@ public class GdprServiceTests
         var result = await _sut.ExportUserDataAsync(userId);
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("User not found.", result.Error);
+        Assert.Equal("Användare hittades inte.", result.Error);
     }
 
     [Fact]
@@ -131,12 +138,12 @@ public class GdprServiceTests
         var userId = user.Id;
 
         _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _passwordHasher.Verify("CorrectPass123!", "hashedpass").Returns(true);
 
-        var result = await _sut.RequestDataDeletionAsync(userId);
+        var result = await _sut.RequestDataDeletionAsync(userId, "CorrectPass123!", null);
 
         Assert.True(result.IsSuccess);
         Assert.True(result.Value!.Success);
-        Assert.Contains("permanently deleted", result.Value.Message);
         await _refreshTokenRepository.Received(1).RevokeAllForUserAsync(userId, Arg.Any<CancellationToken>());
         await _userRepository.Received(1).DeleteAsync(userId, Arg.Any<CancellationToken>());
     }
@@ -147,10 +154,25 @@ public class GdprServiceTests
         var userId = Guid.NewGuid();
         _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns((User?)null);
 
-        var result = await _sut.RequestDataDeletionAsync(userId);
+        var result = await _sut.RequestDataDeletionAsync(userId, "anypass", null);
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("User not found.", result.Error);
+        Assert.Equal("Användare hittades inte.", result.Error);
+    }
+
+    [Fact]
+    public async Task RequestDataDeletion_WrongPassword_ReturnsFailure()
+    {
+        var user = User.Create("delete@example.com", "hashedpass");
+        var userId = user.Id;
+
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _passwordHasher.Verify("wrongpass", "hashedpass").Returns(false);
+
+        var result = await _sut.RequestDataDeletionAsync(userId, "wrongpass", null);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Felaktigt lösenord.", result.Error);
     }
 
     [Fact]
@@ -160,8 +182,9 @@ public class GdprServiceTests
         var userId = user.Id;
 
         _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _passwordHasher.Verify("CorrectPass123!", "hashedpass").Returns(true);
 
-        await _sut.RequestDataDeletionAsync(userId);
+        await _sut.RequestDataDeletionAsync(userId, "CorrectPass123!", null);
 
         Received.InOrder(() =>
         {
@@ -178,8 +201,9 @@ public class GdprServiceTests
         var userId = user.Id;
 
         _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _passwordHasher.Verify("CorrectPass123!", "hashedpass").Returns(true);
 
-        await _sut.RequestDataDeletionAsync(userId);
+        await _sut.RequestDataDeletionAsync(userId, "CorrectPass123!", null);
 
         await _securityEventLogger.Received(1).LogAsync(userId, "DataDeletionRequested", null, Arg.Any<CancellationToken>());
     }

--- a/backend/tests/CarCheck.Application.Tests/History/SearchHistoryServiceTests.cs
+++ b/backend/tests/CarCheck.Application.Tests/History/SearchHistoryServiceTests.cs
@@ -135,7 +135,7 @@ public class SearchHistoryServiceTests
         var result = await _sut.DeleteEntryAsync(userId, entryId);
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("Entry not found.", result.Error);
+        Assert.Equal("Historikposten hittades inte.", result.Error);
     }
 
     [Fact]
@@ -151,7 +151,7 @@ public class SearchHistoryServiceTests
         var result = await _sut.DeleteEntryAsync(userId, entry.Id);
 
         Assert.False(result.IsSuccess);
-        Assert.Equal("Entry not found.", result.Error);
+        Assert.Equal("Historikposten hittades inte.", result.Error);
         await _searchHistoryRepository.DidNotReceive().DeleteByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 

--- a/frontend/src/api/auth.api.ts
+++ b/frontend/src/api/auth.api.ts
@@ -2,11 +2,10 @@ import apiClient from './client'
 import type {
   RegisterRequest,
   LoginRequest,
-  RefreshRequest,
   ChangePasswordRequest,
   ForgotPasswordRequest,
   ResetPasswordRequest,
-  AuthResponse,
+  AuthTokenResponse,
   UserResponse,
 } from '@/types/auth.types'
 
@@ -15,13 +14,15 @@ export const authApi = {
     apiClient.post<UserResponse>('/auth/register', data),
 
   login: (data: LoginRequest) =>
-    apiClient.post<AuthResponse>('/auth/login', data),
+    apiClient.post<AuthTokenResponse>('/auth/login', data),
 
-  refresh: (data: RefreshRequest) =>
-    apiClient.post<AuthResponse>('/auth/refresh', data),
+  // Refresh token is in an HttpOnly cookie — no body needed
+  refresh: () =>
+    apiClient.post<AuthTokenResponse>('/auth/refresh', {}),
 
-  logout: (data: RefreshRequest) =>
-    apiClient.post('/auth/logout', data),
+  // Logout revokes the HttpOnly cookie on the server side
+  logout: () =>
+    apiClient.post('/auth/logout'),
 
   logoutAll: () =>
     apiClient.post('/auth/logout-all'),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,9 +7,11 @@ const apiClient = axios.create({
   baseURL: '/api',
   headers: { 'Content-Type': 'application/json' },
   timeout: 10_000,
+  // Needed so the browser sends the HttpOnly refresh-token cookie on cross-origin requests
+  withCredentials: true,
 })
 
-// Request interceptor: attach access token
+// Request interceptor: attach in-memory access token
 apiClient.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   const tokens = getTokens()
   if (tokens?.accessToken) {
@@ -84,16 +86,11 @@ apiClient.interceptors.response.use(
       isRefreshing = true
 
       try {
-        const tokens = getTokens()
-        if (!tokens?.refreshToken) throw new Error('No refresh token')
-
-        const { data } = await axios.post('/api/auth/refresh', {
-          refreshToken: tokens.refreshToken,
-        })
+        // Refresh token is in an HttpOnly cookie — sent automatically (withCredentials: true)
+        const { data } = await axios.post('/api/auth/refresh', {}, { withCredentials: true })
 
         setTokens({
           accessToken: data.accessToken,
-          refreshToken: data.refreshToken,
           expiresAt: data.expiresAt,
         })
 

--- a/frontend/src/features/auth/login-page.tsx
+++ b/frontend/src/features/auth/login-page.tsx
@@ -8,9 +8,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { useAuth } from '@/hooks/use-auth'
-import { authApi } from '@/api/auth.api'
 import { loginSchema, type LoginFormData } from '@/lib/validators'
-import { toast } from 'sonner'
 import type { AxiosError } from 'axios'
 
 const FEATURES = [
@@ -26,8 +24,6 @@ export function LoginPage() {
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
-  const [unverifiedEmail, setUnverifiedEmail] = useState<string | null>(null)
-  const [resendSent, setResendSent] = useState(false)
 
   const fromState = (location.state as { from?: { pathname: string } })?.from?.pathname
   const fromQuery = new URLSearchParams(location.search).get('from')
@@ -43,8 +39,6 @@ export function LoginPage() {
   })
 
   const onSubmit = async (data: LoginFormData) => {
-    setUnverifiedEmail(null)
-    setResendSent(false)
     setIsSubmitting(true)
     try {
       await login(data)
@@ -54,26 +48,10 @@ export function LoginPage() {
         navigate(from, { replace: true })
       }
     } catch (err) {
-      const axiosError = err as AxiosError<{ error?: string; code?: string }>
-      const code = axiosError.response?.data?.code
-      if (code === 'email_not_verified') {
-        setUnverifiedEmail(data.email)
-        setError(null)
-      } else {
-        setError(axiosError.response?.data?.error || 'Inloggningen misslyckades. Försök igen.')
-      }
+      const axiosError = err as AxiosError<{ error?: string }>
+      setError(axiosError.response?.data?.error || 'Inloggningen misslyckades. Försök igen.')
     } finally {
       setIsSubmitting(false)
-    }
-  }
-
-  const handleResend = async () => {
-    if (!unverifiedEmail) return
-    try {
-      await authApi.resendVerification(unverifiedEmail)
-      setResendSent(true)
-    } catch {
-      toast.error('Kunde inte skicka verifieringslänk. Försök igen.')
     }
   }
 
@@ -165,24 +143,6 @@ export function LoginPage() {
             {error && (
               <Alert variant="destructive">
                 <AlertDescription>{error}</AlertDescription>
-              </Alert>
-            )}
-            {unverifiedEmail && (
-              <Alert>
-                <AlertDescription className="space-y-2">
-                  <p>Du behöver verifiera din e-postadress innan du kan logga in. Kolla din inkorg.</p>
-                  {resendSent ? (
-                    <p className="text-sm font-medium text-green-600">En ny verifieringslänk har skickats!</p>
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={handleResend}
-                      className="text-sm font-medium underline hover:no-underline"
-                    >
-                      Skicka ny verifieringslänk
-                    </button>
-                  )}
-                </AlertDescription>
               </Alert>
             )}
 

--- a/frontend/src/hooks/use-auth.tsx
+++ b/frontend/src/hooks/use-auth.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { authApi } from '@/api/auth.api'
-import { getTokens, setTokens, clearTokens } from '@/lib/token'
+import { setTokens, clearTokens } from '@/lib/token'
 import type { LoginRequest, RegisterRequest } from '@/types/auth.types'
 
 interface AuthState {
@@ -66,21 +66,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   })
   const queryClient = useQueryClient()
 
+  // Restore session from the HttpOnly refresh-token cookie via silent refresh
   useEffect(() => {
-    const tokens = getTokens()
-    if (tokens?.accessToken) {
-      const email = getEmailFromToken(tokens.accessToken)
-      dispatch({ type: 'LOGIN_SUCCESS', email: email || '' })
-    } else {
-      dispatch({ type: 'SET_LOADING', isLoading: false })
-    }
-  }, [])
+    authApi.refresh()
+      .then((response) => {
+        const { accessToken, expiresAt } = response.data
+        setTokens({ accessToken, expiresAt })
+        const email = getEmailFromToken(accessToken)
+        dispatch({ type: 'LOGIN_SUCCESS', email: email || '' })
+      })
+      .catch(() => {
+        // No valid session (no cookie or expired) — user is logged out
+        dispatch({ type: 'SET_LOADING', isLoading: false })
+      })
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const login = useCallback(async (data: LoginRequest) => {
     const response = await authApi.login(data)
     setTokens({
       accessToken: response.data.accessToken,
-      refreshToken: response.data.refreshToken,
       expiresAt: response.data.expiresAt,
     })
     queryClient.clear()
@@ -94,10 +98,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(async () => {
     try {
-      const tokens = getTokens()
-      if (tokens?.refreshToken) {
-        await authApi.logout({ refreshToken: tokens.refreshToken })
-      }
+      await authApi.logout()
     } finally {
       clearTokens()
       queryClient.clear()

--- a/frontend/src/lib/token.ts
+++ b/frontend/src/lib/token.ts
@@ -1,29 +1,28 @@
-const ACCESS_TOKEN_KEY = 'carcheck_at'
-const REFRESH_TOKEN_KEY = 'carcheck_rt'
-const EXPIRES_AT_KEY = 'carcheck_exp'
+/**
+ * In-memory access token storage.
+ * The refresh token is stored in an HttpOnly cookie (server-side) and never
+ * accessible from JavaScript — mitigating XSS token theft.
+ */
+
+let _accessToken: string | null = null
+let _expiresAt: string | null = null
 
 export interface TokenData {
   accessToken: string
-  refreshToken: string
   expiresAt: string
 }
 
 export function getTokens(): TokenData | null {
-  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY)
-  const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY)
-  const expiresAt = localStorage.getItem(EXPIRES_AT_KEY)
-  if (!accessToken || !refreshToken) return null
-  return { accessToken, refreshToken, expiresAt: expiresAt || '' }
+  if (!_accessToken) return null
+  return { accessToken: _accessToken, expiresAt: _expiresAt || '' }
 }
 
 export function setTokens(data: TokenData): void {
-  localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken)
-  localStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken)
-  localStorage.setItem(EXPIRES_AT_KEY, data.expiresAt)
+  _accessToken = data.accessToken
+  _expiresAt = data.expiresAt
 }
 
 export function clearTokens(): void {
-  localStorage.removeItem(ACCESS_TOKEN_KEY)
-  localStorage.removeItem(REFRESH_TOKEN_KEY)
-  localStorage.removeItem(EXPIRES_AT_KEY)
+  _accessToken = null
+  _expiresAt = null
 }

--- a/frontend/src/lib/validators.ts
+++ b/frontend/src/lib/validators.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod'
 
+const passwordSchema = z
+  .string()
+  .min(12, 'Lösenordet måste vara minst 12 tecken')
+  .regex(/[A-Z]/, 'Lösenordet måste innehålla minst en stor bokstav')
+  .regex(/[0-9]/, 'Lösenordet måste innehålla minst en siffra')
+
 export const loginSchema = z.object({
   email: z.string().email('Ange en giltig e-postadress'),
   password: z.string().min(1, 'Ange ditt lösenord'),
@@ -8,7 +14,7 @@ export const loginSchema = z.object({
 export const registerSchema = z
   .object({
     email: z.string().email('Ange en giltig e-postadress'),
-    password: z.string().min(8, 'Lösenordet måste vara minst 8 tecken'),
+    password: passwordSchema,
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {
@@ -19,7 +25,7 @@ export const registerSchema = z
 export const changePasswordSchema = z
   .object({
     currentPassword: z.string().min(1, 'Ange ditt nuvarande lösenord'),
-    newPassword: z.string().min(8, 'Lösenordet måste vara minst 8 tecken'),
+    newPassword: passwordSchema,
     confirmNewPassword: z.string(),
   })
   .refine((data) => data.newPassword === data.confirmNewPassword, {
@@ -41,7 +47,7 @@ export const forgotPasswordSchema = z.object({
 
 export const resetPasswordSchema = z
   .object({
-    newPassword: z.string().min(8, 'Lösenordet måste vara minst 8 tecken'),
+    newPassword: passwordSchema,
     confirmPassword: z.string(),
   })
   .refine((data) => data.newPassword === data.confirmPassword, {

--- a/frontend/src/types/auth.types.ts
+++ b/frontend/src/types/auth.types.ts
@@ -8,10 +8,6 @@ export interface LoginRequest {
   password: string
 }
 
-export interface RefreshRequest {
-  refreshToken: string
-}
-
 export interface ChangePasswordRequest {
   currentPassword: string
   newPassword: string
@@ -26,6 +22,13 @@ export interface ResetPasswordRequest {
   newPassword: string
 }
 
+// accessToken only — refresh token lives in an HttpOnly cookie
+export interface AuthTokenResponse {
+  accessToken: string
+  expiresAt: string
+}
+
+/** @deprecated Use AuthTokenResponse. Kept for reference only. */
 export interface AuthResponse {
   accessToken: string
   refreshToken: string


### PR DESCRIPTION
## Summary

Full implementation of all actionable security findings from the external audit:

### Critical
- **VULN-001** Refresh token moved from localStorage to HttpOnly cookie — eliminates XSS token theft. Access token stored in memory only.
- **VULN-004** Account lockout after 5 failed logins (30-minute lockout) — prevents brute force. Adds `failed_login_attempts` + `lockout_until` columns (migration included).
- **VULN-005** Token generation switched from `Guid.NewGuid()` to `RandomNumberGenerator.GetBytes(32)` — 256-bit cryptographically secure tokens for password reset and email verification.
- **VULN-006** Stripe webhook now **requires** `Stripe:WebhookSecret` — unsigned webhooks are rejected (no fallback).

### High
- **VULN-002** HTTP security headers added: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, `Strict-Transport-Security`, CSP.
- **VULN-003** `MockCaptchaService` throws `InvalidOperationException` at startup in production.
- **VULN-009** `Jwt:Secret` validated ≥ 32 characters at startup — prevents weak secrets in production.
- **VULN-010** Per-email rate limiting on `forgot-password` and `resend-verification` — max 3 emails/email/hour.

### Medium
- **VULN-007** CORS tightened to specific methods + headers only, with `AllowCredentials()` for cookie support.
- **VULN-008** Password requirements raised: min 12 chars + uppercase + digit (frontend + backend).
- **VULN-012** `ExecuteSqlRawAsync` → `ExecuteSqlInterpolatedAsync` in DeletionFeedbackRepository.
- **VULN-013** Login no longer returns `code: "email_not_verified"` — generic error for all failures.
- **VULN-015** Resend API key injected via `DelegatingHandler` instead of `DefaultRequestHeaders`.
- **VULN-019** Refresh token rotation now logged as `TokenRefreshed` security event.
- **VULN-023** Startup warning if `Frontend:BaseUrl` is not HTTPS in production.

### CI/CD
- **DEPLOY-002** Smoke tests now actually run: health endpoint + security header verification.
- **DEPLOY-004** CI path filters + new frontend TypeScript type-check job.
- **VULN-021** Security scan fails CI if vulnerable packages are detected.

## DB migration
New migration `20260314000000_AddUserLockout` adds two nullable columns to `users`:
- `failed_login_attempts integer DEFAULT 0`
- `lockout_until timestamp with time zone`

## Test plan
- [x] `dotnet test` — all 295 tests pass
- [x] `npx tsc --noEmit` — zero TypeScript errors
- [x] `dotnet build` — clean build
- [ ] Deploy to staging and verify cookie behavior cross-origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)